### PR TITLE
Fix the client option naming inconsistancy

### DIFF
--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/review/arm-networkanalytics.api.md
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/review/arm-networkanalytics.api.md
@@ -428,7 +428,7 @@ export type ManagedServiceIdentityType = string;
 
 // @public (undocumented)
 export class NetworkAnalyticsClient {
-    constructor(credential: TokenCredential, subscriptionId: string, options?: NetworkAnalyticsClientOptions);
+    constructor(credential: TokenCredential, subscriptionId: string, options?: NetworkAnalyticsClientOptionalParams);
     readonly dataProducts: DataProductsOperations;
     readonly dataProductsCatalogs: DataProductsCatalogsOperations;
     readonly dataTypes: DataTypesOperations;
@@ -437,7 +437,7 @@ export class NetworkAnalyticsClient {
 }
 
 // @public
-export interface NetworkAnalyticsClientOptions extends ClientOptions {
+export interface NetworkAnalyticsClientOptionalParams extends ClientOptions {
     apiVersion?: string;
 }
 

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createNetworkAnalytics,
-  NetworkAnalyticsClientOptions,
+  NetworkAnalyticsClientOptionalParams,
   NetworkAnalyticsContext,
 } from "./networkAnalyticsContext.js";

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/networkAnalyticsContext.ts
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/networkAnalyticsContext.ts
@@ -7,7 +7,7 @@ import { NetworkAnalyticsContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface NetworkAnalyticsClientOptions extends ClientOptions {
+export interface NetworkAnalyticsClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -16,7 +16,7 @@ export { NetworkAnalyticsContext } from "../rest/index.js";
 
 export function createNetworkAnalytics(
   credential: TokenCredential,
-  options: NetworkAnalyticsClientOptions = {},
+  options: NetworkAnalyticsClientOptionalParams = {},
 ): NetworkAnalyticsContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   NetworkAnalyticsClient,
-  NetworkAnalyticsClientOptions,
+  NetworkAnalyticsClientOptionalParams,
 } from "./networkAnalyticsClient.js";
 export { restorePoller, RestorePollerOptions } from "./restorePollerHelpers.js";
 export {

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/networkAnalyticsClient.ts
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/networkAnalyticsClient.ts
@@ -21,11 +21,11 @@ import {
 } from "./classic/dataProducts/index.js";
 import {
   createNetworkAnalytics,
-  NetworkAnalyticsClientOptions,
+  NetworkAnalyticsClientOptionalParams,
   NetworkAnalyticsContext,
 } from "./api/index.js";
 
-export { NetworkAnalyticsClientOptions } from "./api/networkAnalyticsContext.js";
+export { NetworkAnalyticsClientOptionalParams } from "./api/networkAnalyticsContext.js";
 
 export class NetworkAnalyticsClient {
   private _client: NetworkAnalyticsContext;
@@ -35,7 +35,7 @@ export class NetworkAnalyticsClient {
   constructor(
     credential: TokenCredential,
     subscriptionId: string,
-    options: NetworkAnalyticsClientOptions = {},
+    options: NetworkAnalyticsClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/review/ai-anomaly-detector.api.md
+++ b/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/review/ai-anomaly-detector.api.md
@@ -14,14 +14,14 @@ export type AlignMode = "Inner" | "Outer";
 
 // @public (undocumented)
 export class AnomalyDetectorClient {
-    constructor(endpointParam: string, credential: KeyCredential, options?: AnomalyDetectorClientOptions);
+    constructor(endpointParam: string, credential: KeyCredential, options?: AnomalyDetectorClientOptionalParams);
     readonly multivariate: MultivariateOperations;
     readonly pipeline: Pipeline;
     readonly univariate: UnivariateOperations;
 }
 
 // @public
-export interface AnomalyDetectorClientOptions extends ClientOptions {
+export interface AnomalyDetectorClientOptionalParams extends ClientOptions {
     apiVersion?: string;
 }
 

--- a/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/src/anomalyDetectorClient.ts
+++ b/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/src/anomalyDetectorClient.ts
@@ -13,11 +13,11 @@ import {
 } from "./classic/multivariate/index.js";
 import {
   createAnomalyDetector,
-  AnomalyDetectorClientOptions,
+  AnomalyDetectorClientOptionalParams,
   AnomalyDetectorContext,
 } from "./api/index.js";
 
-export { AnomalyDetectorClientOptions } from "./api/anomalyDetectorContext.js";
+export { AnomalyDetectorClientOptionalParams } from "./api/anomalyDetectorContext.js";
 
 export class AnomalyDetectorClient {
   private _client: AnomalyDetectorContext;
@@ -45,7 +45,7 @@ export class AnomalyDetectorClient {
   constructor(
     endpointParam: string,
     credential: KeyCredential,
-    options: AnomalyDetectorClientOptions = {},
+    options: AnomalyDetectorClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/src/api/anomalyDetectorContext.ts
+++ b/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/src/api/anomalyDetectorContext.ts
@@ -7,7 +7,7 @@ import { AnomalyDetectorContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface AnomalyDetectorClientOptions extends ClientOptions {
+export interface AnomalyDetectorClientOptionalParams extends ClientOptions {
   /** Api Version */
   apiVersion?: string;
 }
@@ -35,7 +35,7 @@ export { AnomalyDetectorContext } from "../rest/index.js";
 export function createAnomalyDetector(
   endpointParam: string,
   credential: KeyCredential,
-  options: AnomalyDetectorClientOptions = {},
+  options: AnomalyDetectorClientOptionalParams = {},
 ): AnomalyDetectorContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createAnomalyDetector,
-  AnomalyDetectorClientOptions,
+  AnomalyDetectorClientOptionalParams,
   AnomalyDetectorContext,
 } from "./anomalyDetectorContext.js";

--- a/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   AnomalyDetectorClient,
-  AnomalyDetectorClientOptions,
+  AnomalyDetectorClientOptionalParams,
 } from "./anomalyDetectorClient.js";
 export {
   MultivariateMultivariateDetectionResult,

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/review/batch.api.md
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/review/batch.api.md
@@ -107,7 +107,7 @@ export interface BatchCertificate {
 
 // @public (undocumented)
 export class BatchClient {
-    constructor(endpointParam: string, credential: TokenCredential, options?: BatchClientOptions);
+    constructor(endpointParam: string, credential: TokenCredential, options?: BatchClientOptionalParams);
     cancelCertificateDeletion(thumbprintAlgorithm: string, thumbprint: string, options?: CancelCertificateDeletionOptionalParams): Promise<void>;
     createCertificate(body: BatchCertificate, options?: CreateCertificateOptionalParams): Promise<void>;
     createJob(body: BatchJobCreateOptions, options?: CreateJobOptionalParams): Promise<void>;
@@ -188,7 +188,7 @@ export class BatchClient {
 }
 
 // @public
-export interface BatchClientOptions extends ClientOptions {
+export interface BatchClientOptionalParams extends ClientOptions {
 }
 
 // @public

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/batchContext.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/batchContext.ts
@@ -7,7 +7,7 @@ import { BatchContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface BatchClientOptions extends ClientOptions {}
+export interface BatchClientOptionalParams extends ClientOptions {}
 
 export { BatchContext } from "../rest/index.js";
 
@@ -15,7 +15,7 @@ export { BatchContext } from "../rest/index.js";
 export function createBatch(
   endpointParam: string,
   credential: TokenCredential,
-  options: BatchClientOptions = {},
+  options: BatchClientOptionalParams = {},
 ): BatchContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createBatch,
-  BatchClientOptions,
+  BatchClientOptionalParams,
   BatchContext,
 } from "./batchContext.js";
 export {

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/batchClient.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/batchClient.ts
@@ -126,7 +126,7 @@ import {
 import { PagedAsyncIterableIterator } from "./models/pagingTypes.js";
 import {
   createBatch,
-  BatchClientOptions,
+  BatchClientOptionalParams,
   BatchContext,
   listApplications,
   getApplication,
@@ -206,7 +206,7 @@ import {
   listNodeFiles,
 } from "./api/index.js";
 
-export { BatchClientOptions } from "./api/batchContext.js";
+export { BatchClientOptionalParams } from "./api/batchContext.js";
 
 export class BatchClient {
   private _client: BatchContext;
@@ -217,7 +217,7 @@ export class BatchClient {
   constructor(
     endpointParam: string,
     credential: TokenCredential,
-    options: BatchClientOptions = {},
+    options: BatchClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { BatchClient, BatchClientOptions } from "./batchClient.js";
+export { BatchClient, BatchClientOptionalParams } from "./batchClient.js";
 export {
   BatchNodeUserCreateOptions,
   BatchError,

--- a/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/review/ai-chat-protocol.api.md
+++ b/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/review/ai-chat-protocol.api.md
@@ -56,14 +56,14 @@ export interface ChatMessageDelta {
 
 // @public (undocumented)
 export class ChatProtocolClient {
-    constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: ChatProtocolClientOptions);
+    constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: ChatProtocolClientOptionalParams);
     create(body: ChatCompletionOptionsRecord, options?: CreateOptionalParams): Promise<ChatCompletionRecord>;
     createStreaming(body: StreamingChatCompletionOptionsRecord, options?: CreateStreamingOptionalParams): Promise<ChatCompletionChunkRecord>;
     readonly pipeline: Pipeline;
 }
 
 // @public
-export interface ChatProtocolClientOptions extends ClientOptions {
+export interface ChatProtocolClientOptionalParams extends ClientOptions {
 }
 
 // @public

--- a/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/src/api/chatProtocolContext.ts
+++ b/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/src/api/chatProtocolContext.ts
@@ -7,7 +7,7 @@ import { ChatProtocolContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ChatProtocolClientOptions extends ClientOptions {}
+export interface ChatProtocolClientOptionalParams extends ClientOptions {}
 
 export { ChatProtocolContext } from "../rest/index.js";
 
@@ -15,7 +15,7 @@ export { ChatProtocolContext } from "../rest/index.js";
 export function createChatProtocol(
   endpointParam: string,
   credential: KeyCredential | TokenCredential,
-  options: ChatProtocolClientOptions = {},
+  options: ChatProtocolClientOptionalParams = {},
 ): ChatProtocolContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createChatProtocol,
-  ChatProtocolClientOptions,
+  ChatProtocolClientOptionalParams,
   ChatProtocolContext,
 } from "./chatProtocolContext.js";
 export { createStreaming, create } from "./operations.js";

--- a/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/src/chatProtocolClient.ts
+++ b/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/src/chatProtocolClient.ts
@@ -15,13 +15,13 @@ import {
 } from "./models/options.js";
 import {
   createChatProtocol,
-  ChatProtocolClientOptions,
+  ChatProtocolClientOptionalParams,
   ChatProtocolContext,
   createStreaming,
   create,
 } from "./api/index.js";
 
-export { ChatProtocolClientOptions } from "./api/chatProtocolContext.js";
+export { ChatProtocolClientOptionalParams } from "./api/chatProtocolContext.js";
 
 export class ChatProtocolClient {
   private _client: ChatProtocolContext;
@@ -32,7 +32,7 @@ export class ChatProtocolClient {
   constructor(
     endpointParam: string,
     credential: KeyCredential | TokenCredential,
-    options: ChatProtocolClientOptions = {},
+    options: ChatProtocolClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   ChatProtocolClient,
-  ChatProtocolClientOptions,
+  ChatProtocolClientOptionalParams,
 } from "./chatProtocolClient.js";
 export {
   ChatMessage,

--- a/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/review/ai-content-safety.api.md
+++ b/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/review/ai-content-safety.api.md
@@ -67,7 +67,7 @@ export interface AnalyzeTextResult {
 
 // @public (undocumented)
 export class ContentSafetyClient {
-    constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: ContentSafetyClientOptions);
+    constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: ContentSafetyClientOptionalParams);
     addOrUpdateBlockItems(blocklistName: string, body: AddOrUpdateBlockItemsOptions, options?: AddOrUpdateBlockItemsOptionalParams): Promise<AddOrUpdateBlockItemsResult>;
     analyzeImage(body: AnalyzeImageOptions, options?: AnalyzeImageOptionalParams): Promise<AnalyzeImageResult>;
     analyzeText(body: AnalyzeTextOptions, options?: AnalyzeTextOptionalParams): Promise<AnalyzeTextResult>;
@@ -82,7 +82,7 @@ export class ContentSafetyClient {
 }
 
 // @public
-export interface ContentSafetyClientOptions extends ClientOptions {
+export interface ContentSafetyClientOptionalParams extends ClientOptions {
     apiVersion?: string;
 }
 

--- a/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/src/api/contentSafetyContext.ts
+++ b/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/src/api/contentSafetyContext.ts
@@ -7,7 +7,7 @@ import { ContentSafetyContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ContentSafetyClientOptions extends ClientOptions {
+export interface ContentSafetyClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -18,7 +18,7 @@ export { ContentSafetyContext } from "../rest/index.js";
 export function createContentSafety(
   endpointParam: string,
   credential: KeyCredential | TokenCredential,
-  options: ContentSafetyClientOptions = {},
+  options: ContentSafetyClientOptionalParams = {},
 ): ContentSafetyContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createContentSafety,
-  ContentSafetyClientOptions,
+  ContentSafetyClientOptionalParams,
   ContentSafetyContext,
 } from "./contentSafetyContext.js";
 export {

--- a/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/src/contentSafetyClient.ts
+++ b/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/src/contentSafetyClient.ts
@@ -29,7 +29,7 @@ import {
 import { PagedAsyncIterableIterator } from "./models/pagingTypes.js";
 import {
   createContentSafety,
-  ContentSafetyClientOptions,
+  ContentSafetyClientOptionalParams,
   ContentSafetyContext,
   analyzeText,
   analyzeImage,
@@ -43,7 +43,7 @@ import {
   listTextBlocklistItems,
 } from "./api/index.js";
 
-export { ContentSafetyClientOptions } from "./api/contentSafetyContext.js";
+export { ContentSafetyClientOptionalParams } from "./api/contentSafetyContext.js";
 
 export class ContentSafetyClient {
   private _client: ContentSafetyContext;
@@ -54,7 +54,7 @@ export class ContentSafetyClient {
   constructor(
     endpointParam: string,
     credential: KeyCredential | TokenCredential,
-    options: ContentSafetyClientOptions = {},
+    options: ContentSafetyClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   ContentSafetyClient,
-  ContentSafetyClientOptions,
+  ContentSafetyClientOptionalParams,
 } from "./contentSafetyClient.js";
 export {
   TextBlocklist,

--- a/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/review/eventgrid.api.md
+++ b/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/review/eventgrid.api.md
@@ -47,7 +47,7 @@ export interface CloudEvent {
 
 // @public (undocumented)
 export class EventGridClient {
-    constructor(endpointParam: string, credential: KeyCredential, options?: EventGridClientOptions);
+    constructor(endpointParam: string, credential: KeyCredential, options?: EventGridClientOptionalParams);
     acknowledgeCloudEvents(topicName: string, eventSubscriptionName: string, lockTokens: AcknowledgeOptions, options?: AcknowledgeCloudEventsOptionalParams): Promise<AcknowledgeResult>;
     readonly pipeline: Pipeline;
     publishCloudEvent(topicName: string, event: CloudEvent, options?: PublishCloudEventOptionalParams): Promise<PublishResult>;
@@ -58,7 +58,7 @@ export class EventGridClient {
 }
 
 // @public
-export interface EventGridClientOptions extends ClientOptions {
+export interface EventGridClientOptionalParams extends ClientOptions {
     apiVersion?: string;
 }
 

--- a/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/src/api/eventGridContext.ts
+++ b/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/src/api/eventGridContext.ts
@@ -7,7 +7,7 @@ import { EventGridContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface EventGridClientOptions extends ClientOptions {
+export interface EventGridClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -18,7 +18,7 @@ export { EventGridContext } from "../rest/index.js";
 export function createEventGrid(
   endpointParam: string,
   credential: KeyCredential,
-  options: EventGridClientOptions = {},
+  options: EventGridClientOptionalParams = {},
 ): EventGridContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createEventGrid,
-  EventGridClientOptions,
+  EventGridClientOptionalParams,
   EventGridContext,
 } from "./eventGridContext.js";
 export {

--- a/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/src/eventGridClient.ts
+++ b/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/src/eventGridClient.ts
@@ -24,7 +24,7 @@ import {
 } from "./models/options.js";
 import {
   createEventGrid,
-  EventGridClientOptions,
+  EventGridClientOptionalParams,
   EventGridContext,
   publishCloudEvent,
   publishCloudEvents,
@@ -34,7 +34,7 @@ import {
   rejectCloudEvents,
 } from "./api/index.js";
 
-export { EventGridClientOptions } from "./api/eventGridContext.js";
+export { EventGridClientOptionalParams } from "./api/eventGridContext.js";
 
 export class EventGridClient {
   private _client: EventGridContext;
@@ -45,7 +45,7 @@ export class EventGridClient {
   constructor(
     endpointParam: string,
     credential: KeyCredential,
-    options: EventGridClientOptions = {},
+    options: EventGridClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { EventGridClient, EventGridClientOptions } from "./eventGridClient.js";
+export {
+  EventGridClient,
+  EventGridClientOptionalParams,
+} from "./eventGridClient.js";
 export {
   CloudEvent,
   PublishResult,

--- a/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/review/hierarchy-generic.api.md
+++ b/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/review/hierarchy-generic.api.md
@@ -78,7 +78,7 @@ export interface DOperations {
 
 // @public (undocumented)
 export class FooClient {
-    constructor(endpoint: string, options?: FooClientOptions);
+    constructor(endpoint: string, options?: FooClientOptionalParams);
     readonly b: BOperations;
     readonly d: DOperations;
     // (undocumented)
@@ -87,7 +87,7 @@ export class FooClient {
 }
 
 // @public
-export interface FooClientOptions extends ClientOptions {
+export interface FooClientOptionalParams extends ClientOptions {
 }
 
 // @public

--- a/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/api/fooContext.ts
+++ b/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/api/fooContext.ts
@@ -6,13 +6,13 @@ import { FooContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface FooClientOptions extends ClientOptions {}
+export interface FooClientOptionalParams extends ClientOptions {}
 
 export { FooContext } from "../rest/index.js";
 
 export function createFoo(
   endpoint: string,
-  options: FooClientOptions = {},
+  options: FooClientOptionalParams = {},
 ): FooContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/api/index.ts
@@ -1,5 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { createFoo, FooClientOptions, FooContext } from "./fooContext.js";
+export {
+  createFoo,
+  FooClientOptionalParams,
+  FooContext,
+} from "./fooContext.js";
 export { op1 } from "./operations.js";

--- a/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/fooClient.ts
+++ b/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/fooClient.ts
@@ -6,16 +6,21 @@ import { A } from "./models/models.js";
 import { Op1OptionalParams } from "./models/options.js";
 import { getBOperations, BOperations } from "./classic/b/index.js";
 import { getDOperations, DOperations } from "./classic/d/index.js";
-import { createFoo, FooClientOptions, FooContext, op1 } from "./api/index.js";
+import {
+  createFoo,
+  FooClientOptionalParams,
+  FooContext,
+  op1,
+} from "./api/index.js";
 
-export { FooClientOptions } from "./api/fooContext.js";
+export { FooClientOptionalParams } from "./api/fooContext.js";
 
 export class FooClient {
   private _client: FooContext;
   /** The pipeline used by this client to make requests */
   public readonly pipeline: Pipeline;
 
-  constructor(endpoint: string, options: FooClientOptions = {}) {
+  constructor(endpoint: string, options: FooClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { FooClient, FooClientOptions } from "./fooClient.js";
+export { FooClient, FooClientOptionalParams } from "./fooClient.js";
 export {
   A,
   BA,

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/review/load-testing.api.md
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/review/load-testing.api.md
@@ -15,7 +15,7 @@ import { TokenCredential } from '@azure/core-auth';
 
 // @public (undocumented)
 export class AdministrationOperationsClient {
-    constructor(endpointParam: string, credential: TokenCredential, options?: AdministrationOperationsClientOptions);
+    constructor(endpointParam: string, credential: TokenCredential, options?: AdministrationOperationsClientOptionalParams);
     createOrUpdateAppComponents(testId: string, body: TestAppComponents, options?: CreateOrUpdateAppComponentsOptionalParams): Promise<TestAppComponents>;
     createOrUpdateServerMetricsConfig(testId: string, body: TestServerMetricConfig, options?: CreateOrUpdateServerMetricsConfigOptionalParams): Promise<TestServerMetricConfig>;
     createOrUpdateTest(testId: string, body: Test, options?: CreateOrUpdateTestOptionalParams): Promise<Test>;
@@ -32,7 +32,7 @@ export class AdministrationOperationsClient {
 }
 
 // @public
-export interface AdministrationOperationsClientOptions extends ClientOptions {
+export interface AdministrationOperationsClientOptionalParams extends ClientOptions {
     apiVersion?: string;
 }
 
@@ -459,7 +459,7 @@ export interface TestRunInputArtifacts {
 
 // @public (undocumented)
 export class TestRunOperationsClient {
-    constructor(endpointParam: string, credential: TokenCredential, options?: TestRunOperationsClientOptions);
+    constructor(endpointParam: string, credential: TokenCredential, options?: TestRunOperationsClientOptionalParams);
     createOrUpdateAppComponents(testRunId: string, body: TestRunOperationsClientTestRunAppComponents, options?: TestRunOperationsClientCreateOrUpdateAppComponentsOptionalParams): Promise<TestRunOperationsClientTestRunAppComponents>;
     createOrUpdateServerMetricsConfig(testRunId: string, body: TestRunOperationsClientTestRunServerMetricConfig, options?: TestRunOperationsClientCreateOrUpdateServerMetricsConfigOptionalParams): Promise<TestRunOperationsClientTestRunServerMetricConfig>;
     deleteTestRun(testRunId: string, options?: DeleteTestRunOptionalParams): Promise<void>;
@@ -641,7 +641,7 @@ export interface TestRunOperationsClientOptionalLoadTestConfig {
 }
 
 // @public
-export interface TestRunOperationsClientOptions extends ClientOptions {
+export interface TestRunOperationsClientOptionalParams extends ClientOptions {
     apiVersion?: string;
 }
 

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/administrationOperationsClient.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/administrationOperationsClient.ts
@@ -26,7 +26,7 @@ import {
 import { PagedAsyncIterableIterator } from "./models/pagingTypes.js";
 import {
   createAdministrationOperations,
-  AdministrationOperationsClientOptions,
+  AdministrationOperationsClientOptionalParams,
   AzureLoadTestingContext,
   createOrUpdateTest,
   createOrUpdateAppComponents,
@@ -42,7 +42,7 @@ import {
   deleteTest,
 } from "./api/index.js";
 
-export { AdministrationOperationsClientOptions } from "./api/administrationOperationsContext.js";
+export { AdministrationOperationsClientOptionalParams } from "./api/administrationOperationsContext.js";
 
 export class AdministrationOperationsClient {
   private _client: AzureLoadTestingContext;
@@ -52,7 +52,7 @@ export class AdministrationOperationsClient {
   constructor(
     endpointParam: string,
     credential: TokenCredential,
-    options: AdministrationOperationsClientOptions = {},
+    options: AdministrationOperationsClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/api/administrationOperationsContext.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/api/administrationOperationsContext.ts
@@ -7,7 +7,8 @@ import { AzureLoadTestingContext } from "../../rest/index.js";
 import getClient from "../../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface AdministrationOperationsClientOptions extends ClientOptions {
+export interface AdministrationOperationsClientOptionalParams
+  extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -17,7 +18,7 @@ export { AzureLoadTestingContext } from "../../rest/index.js";
 export function createAdministrationOperations(
   endpointParam: string,
   credential: TokenCredential,
-  options: AdministrationOperationsClientOptions = {},
+  options: AdministrationOperationsClientOptionalParams = {},
 ): AzureLoadTestingContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/api/index.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createAdministrationOperations,
-  AdministrationOperationsClientOptions,
+  AdministrationOperationsClientOptionalParams,
   AzureLoadTestingContext,
 } from "./administrationOperationsContext.js";
 export {

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/index.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/index.ts
@@ -3,7 +3,7 @@
 
 export {
   AdministrationOperationsClient,
-  AdministrationOperationsClientOptions,
+  AdministrationOperationsClientOptionalParams,
 } from "./administrationOperationsClient.js";
 export {
   Test,

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   AdministrationOperationsClient,
-  AdministrationOperationsClientOptions,
+  AdministrationOperationsClientOptionalParams,
 } from "./administrationOperations/administrationOperationsClient.js";
 export {
   Test,
@@ -72,7 +72,7 @@ export {
 } from "./administrationOperations/models/index.js";
 export {
   TestRunOperationsClient,
-  TestRunOperationsClientOptions,
+  TestRunOperationsClientOptionalParams,
 } from "./testRunOperations/testRunOperationsClient.js";
 export {
   restorePoller,

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/api/index.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/api/index.ts
@@ -19,6 +19,6 @@ export {
 } from "./operations.js";
 export {
   createTestRunOperations,
-  TestRunOperationsClientOptions,
+  TestRunOperationsClientOptionalParams,
   AzureLoadTestingContext,
 } from "./testRunOperationsContext.js";

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/api/testRunOperationsContext.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/api/testRunOperationsContext.ts
@@ -7,7 +7,7 @@ import { AzureLoadTestingContext } from "../../rest/index.js";
 import getClient from "../../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface TestRunOperationsClientOptions extends ClientOptions {
+export interface TestRunOperationsClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -17,7 +17,7 @@ export { AzureLoadTestingContext } from "../../rest/index.js";
 export function createTestRunOperations(
   endpointParam: string,
   credential: TokenCredential,
-  options: TestRunOperationsClientOptions = {},
+  options: TestRunOperationsClientOptionalParams = {},
 ): AzureLoadTestingContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/index.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/index.ts
@@ -3,7 +3,7 @@
 
 export {
   TestRunOperationsClient,
-  TestRunOperationsClientOptions,
+  TestRunOperationsClientOptionalParams,
 } from "./testRunOperationsClient.js";
 export { restorePoller, RestorePollerOptions } from "./restorePollerHelpers.js";
 export {

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/testRunOperationsClient.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/testRunOperationsClient.ts
@@ -48,11 +48,11 @@ import {
   listTestRuns,
   stopTestRun,
   createTestRunOperations,
-  TestRunOperationsClientOptions,
+  TestRunOperationsClientOptionalParams,
   AzureLoadTestingContext,
 } from "./api/index.js";
 
-export { TestRunOperationsClientOptions } from "./api/testRunOperationsContext.js";
+export { TestRunOperationsClientOptionalParams } from "./api/testRunOperationsContext.js";
 
 export class TestRunOperationsClient {
   private _client: AzureLoadTestingContext;
@@ -62,7 +62,7 @@ export class TestRunOperationsClient {
   constructor(
     endpointParam: string,
     credential: TokenCredential,
-    options: TestRunOperationsClientOptions = {},
+    options: TestRunOperationsClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/review/openai-generic.api.md
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/review/openai-generic.api.md
@@ -748,7 +748,7 @@ export interface ModerationsOperations {
 
 // @public (undocumented)
 export class OpenAIClient {
-    constructor(credential: KeyCredential, options?: OpenAIClientOptions);
+    constructor(credential: KeyCredential, options?: OpenAIClientOptionalParams);
     readonly audio: AudioOperations;
     readonly chat: ChatOperations;
     readonly completions: CompletionsOperations;
@@ -764,7 +764,7 @@ export class OpenAIClient {
 }
 
 // @public
-export interface OpenAIClientOptions extends ClientOptions {
+export interface OpenAIClientOptionalParams extends ClientOptions {
 }
 
 // @public

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createOpenAI,
-  OpenAIClientOptions,
+  OpenAIClientOptionalParams,
   OpenAIContext,
 } from "./openAIContext.js";

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/openAIContext.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/openAIContext.ts
@@ -7,14 +7,14 @@ import { OpenAIContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface OpenAIClientOptions extends ClientOptions {}
+export interface OpenAIClientOptionalParams extends ClientOptions {}
 
 export { OpenAIContext } from "../rest/index.js";
 
 /** The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details. */
 export function createOpenAI(
   credential: KeyCredential,
-  options: OpenAIClientOptions = {},
+  options: OpenAIClientOptionalParams = {},
 ): OpenAIContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { OpenAIClient, OpenAIClientOptions } from "./openAIClient.js";
+export { OpenAIClient, OpenAIClientOptionalParams } from "./openAIClient.js";
 export {
   CreateModerationRequest,
   CreateModerationResponse,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/openAIClient.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/openAIClient.ts
@@ -37,11 +37,11 @@ import {
 } from "./classic/moderations/index.js";
 import {
   createOpenAI,
-  OpenAIClientOptions,
+  OpenAIClientOptionalParams,
   OpenAIContext,
 } from "./api/index.js";
 
-export { OpenAIClientOptions } from "./api/openAIContext.js";
+export { OpenAIClientOptionalParams } from "./api/openAIContext.js";
 
 export class OpenAIClient {
   private _client: OpenAIContext;
@@ -49,7 +49,10 @@ export class OpenAIClient {
   public readonly pipeline: Pipeline;
 
   /** The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details. */
-  constructor(credential: KeyCredential, options: OpenAIClientOptions = {}) {
+  constructor(
+    credential: KeyCredential,
+    options: OpenAIClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-test/test/openai_modular/generated/typespec-ts/review/openai_modular.api.md
+++ b/packages/typespec-test/test/openai_modular/generated/typespec-ts/review/openai_modular.api.md
@@ -851,7 +851,7 @@ export type OnYourDataVectorizationSourceUnion = OnYourDataEndpointVectorization
 
 // @public (undocumented)
 export class OpenAIClient {
-    constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: OpenAIClientOptions);
+    constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: OpenAIClientOptionalParams);
     getAudioSpeech(deploymentId: string, body: AudioSpeechOptions, options?: GetAudioSpeechOptionalParams): Promise<Uint8Array>;
     getAudioTranscriptionAsPlainText(deploymentId: string, body: AudioTranscriptionOptions, options?: GetAudioTranscriptionAsPlainTextOptionalParams): Promise<string>;
     getAudioTranscriptionAsResponseObject(deploymentId: string, body: AudioTranscriptionOptions, options?: GetAudioTranscriptionAsResponseObjectOptionalParams): Promise<AudioTranscription>;
@@ -865,7 +865,7 @@ export class OpenAIClient {
 }
 
 // @public
-export interface OpenAIClientOptions extends ClientOptions {
+export interface OpenAIClientOptionalParams extends ClientOptions {
     apiVersion?: string;
 }
 

--- a/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createOpenAI,
-  OpenAIClientOptions,
+  OpenAIClientOptionalParams,
   OpenAIContext,
 } from "./openAIContext.js";
 export {

--- a/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/api/openAIContext.ts
+++ b/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/api/openAIContext.ts
@@ -7,7 +7,7 @@ import { OpenAIContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface OpenAIClientOptions extends ClientOptions {
+export interface OpenAIClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -17,7 +17,7 @@ export { OpenAIContext } from "../rest/index.js";
 export function createOpenAI(
   endpointParam: string,
   credential: KeyCredential | TokenCredential,
-  options: OpenAIClientOptions = {},
+  options: OpenAIClientOptionalParams = {},
 ): OpenAIContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { OpenAIClient, OpenAIClientOptions } from "./openAIClient.js";
+export { OpenAIClient, OpenAIClientOptionalParams } from "./openAIClient.js";
 export {
   AudioTranscriptionFormat,
   AudioTranscriptionOptions,

--- a/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/openAIClient.ts
+++ b/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/openAIClient.ts
@@ -31,7 +31,7 @@ import {
 } from "./models/options.js";
 import {
   createOpenAI,
-  OpenAIClientOptions,
+  OpenAIClientOptionalParams,
   OpenAIContext,
   getAudioTranscriptionAsPlainText,
   getAudioTranscriptionAsResponseObject,
@@ -44,7 +44,7 @@ import {
   getEmbeddings,
 } from "./api/index.js";
 
-export { OpenAIClientOptions } from "./api/openAIContext.js";
+export { OpenAIClientOptionalParams } from "./api/openAIContext.js";
 
 export class OpenAIClient {
   private _client: OpenAIContext;
@@ -54,7 +54,7 @@ export class OpenAIClient {
   constructor(
     endpointParam: string,
     credential: KeyCredential | TokenCredential,
-    options: OpenAIClientOptions = {},
+    options: OpenAIClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/review/openai-non-branded.api.md
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/review/openai-non-branded.api.md
@@ -748,7 +748,7 @@ export interface ModerationsOperations {
 
 // @public (undocumented)
 export class OpenAIClient {
-    constructor(credential: KeyCredential, options?: OpenAIClientOptions);
+    constructor(credential: KeyCredential, options?: OpenAIClientOptionalParams);
     readonly audio: AudioOperations;
     readonly chat: ChatOperations;
     readonly completions: CompletionsOperations;
@@ -764,7 +764,7 @@ export class OpenAIClient {
 }
 
 // @public
-export interface OpenAIClientOptions extends ClientOptions {
+export interface OpenAIClientOptionalParams extends ClientOptions {
 }
 
 // @public

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/index.ts
@@ -2,6 +2,6 @@
 
 export {
   createOpenAI,
-  OpenAIClientOptions,
+  OpenAIClientOptionalParams,
   OpenAIContext,
 } from "./openAIContext.js";

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/openAIContext.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/openAIContext.ts
@@ -6,14 +6,14 @@ import { OpenAIContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface OpenAIClientOptions extends ClientOptions {}
+export interface OpenAIClientOptionalParams extends ClientOptions {}
 
 export { OpenAIContext } from "../rest/index.js";
 
 /** The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details. */
 export function createOpenAI(
   credential: KeyCredential,
-  options: OpenAIClientOptions = {},
+  options: OpenAIClientOptionalParams = {},
 ): OpenAIContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/index.ts
@@ -1,6 +1,6 @@
 // Licensed under the MIT license.
 
-export { OpenAIClient, OpenAIClientOptions } from "./openAIClient.js";
+export { OpenAIClient, OpenAIClientOptionalParams } from "./openAIClient.js";
 export {
   CreateModerationRequest,
   CreateModerationResponse,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/openAIClient.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/openAIClient.ts
@@ -36,11 +36,11 @@ import {
 } from "./classic/moderations/index.js";
 import {
   createOpenAI,
-  OpenAIClientOptions,
+  OpenAIClientOptionalParams,
   OpenAIContext,
 } from "./api/index.js";
 
-export { OpenAIClientOptions } from "./api/openAIContext.js";
+export { OpenAIClientOptionalParams } from "./api/openAIContext.js";
 
 export class OpenAIClient {
   private _client: OpenAIContext;
@@ -48,7 +48,10 @@ export class OpenAIClient {
   public readonly pipeline: Pipeline;
 
   /** The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details. */
-  constructor(credential: KeyCredential, options: OpenAIClientOptions = {}) {
+  constructor(
+    credential: KeyCredential,
+    options: OpenAIClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-test/test/overloads_modular/generated/typespec-ts/review/overload_modular.api.md
+++ b/packages/typespec-test/test/overloads_modular/generated/typespec-ts/review/overload_modular.api.md
@@ -33,13 +33,13 @@ export type Versions = "2022-08-30";
 
 // @public (undocumented)
 export class WidgetManagerClient {
-    constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: WidgetManagerClientOptions);
+    constructor(endpointParam: string, credential: KeyCredential | TokenCredential, options?: WidgetManagerClientOptionalParams);
     readonly fooOperations: FooOperationsOperations;
     readonly pipeline: Pipeline;
 }
 
 // @public
-export interface WidgetManagerClientOptions extends ClientOptions {
+export interface WidgetManagerClientOptionalParams extends ClientOptions {
     apiVersion?: string;
 }
 

--- a/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createWidgetManager,
-  WidgetManagerClientOptions,
+  WidgetManagerClientOptionalParams,
   WidgetManagerContext,
 } from "./widgetManagerContext.js";

--- a/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/api/widgetManagerContext.ts
+++ b/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/api/widgetManagerContext.ts
@@ -7,7 +7,7 @@ import { WidgetManagerContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface WidgetManagerClientOptions extends ClientOptions {
+export interface WidgetManagerClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -17,7 +17,7 @@ export { WidgetManagerContext } from "../rest/index.js";
 export function createWidgetManager(
   endpointParam: string,
   credential: KeyCredential | TokenCredential,
-  options: WidgetManagerClientOptions = {},
+  options: WidgetManagerClientOptionalParams = {},
 ): WidgetManagerContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   WidgetManagerClient,
-  WidgetManagerClientOptions,
+  WidgetManagerClientOptionalParams,
 } from "./widgetManagerClient.js";
 export {
   Versions,

--- a/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/widgetManagerClient.ts
+++ b/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/widgetManagerClient.ts
@@ -9,11 +9,11 @@ import {
 } from "./classic/fooOperations/index.js";
 import {
   createWidgetManager,
-  WidgetManagerClientOptions,
+  WidgetManagerClientOptionalParams,
   WidgetManagerContext,
 } from "./api/index.js";
 
-export { WidgetManagerClientOptions } from "./api/widgetManagerContext.js";
+export { WidgetManagerClientOptionalParams } from "./api/widgetManagerContext.js";
 
 export class WidgetManagerClient {
   private _client: WidgetManagerContext;
@@ -23,7 +23,7 @@ export class WidgetManagerClient {
   constructor(
     endpointParam: string,
     credential: KeyCredential | TokenCredential,
-    options: WidgetManagerClientOptions = {},
+    options: WidgetManagerClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/review/parametrized-host.api.md
+++ b/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/review/parametrized-host.api.md
@@ -26,13 +26,13 @@ export interface ConfidentialLedgerOperations {
 
 // @public (undocumented)
 export class ParametrizedHostClient {
-    constructor(credential: TokenCredential, options?: ParametrizedHostClientOptions);
+    constructor(credential: TokenCredential, options?: ParametrizedHostClientOptionalParams);
     readonly confidentialLedger: ConfidentialLedgerOperations;
     readonly pipeline: Pipeline;
 }
 
 // @public
-export interface ParametrizedHostClientOptions extends ClientOptions {
+export interface ParametrizedHostClientOptionalParams extends ClientOptions {
     // (undocumented)
     apiVersion?: string;
     // (undocumented)

--- a/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createParametrizedHost,
-  ParametrizedHostClientOptions,
+  ParametrizedHostClientOptionalParams,
   ParametrizedHostContext,
 } from "./parametrizedHostContext.js";

--- a/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/api/parametrizedHostContext.ts
+++ b/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/api/parametrizedHostContext.ts
@@ -7,7 +7,7 @@ import { ParametrizedHostContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ParametrizedHostClientOptions extends ClientOptions {
+export interface ParametrizedHostClientOptionalParams extends ClientOptions {
   host?: string;
   subdomain?: string;
   sufix?: string;
@@ -18,7 +18,7 @@ export { ParametrizedHostContext } from "../rest/index.js";
 
 export function createParametrizedHost(
   credential: TokenCredential,
-  options: ParametrizedHostClientOptions = {},
+  options: ParametrizedHostClientOptionalParams = {},
 ): ParametrizedHostContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   ParametrizedHostClient,
-  ParametrizedHostClientOptions,
+  ParametrizedHostClientOptionalParams,
 } from "./parametrizedHostClient.js";
 export {
   Collection,

--- a/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/parametrizedHostClient.ts
+++ b/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/parametrizedHostClient.ts
@@ -9,11 +9,11 @@ import {
 } from "./classic/confidentialLedger/index.js";
 import {
   createParametrizedHost,
-  ParametrizedHostClientOptions,
+  ParametrizedHostClientOptionalParams,
   ParametrizedHostContext,
 } from "./api/index.js";
 
-export { ParametrizedHostClientOptions } from "./api/parametrizedHostContext.js";
+export { ParametrizedHostClientOptionalParams } from "./api/parametrizedHostContext.js";
 
 export class ParametrizedHostClient {
   private _client: ParametrizedHostContext;
@@ -22,7 +22,7 @@ export class ParametrizedHostClient {
 
   constructor(
     credential: TokenCredential,
-    options: ParametrizedHostClientOptions = {},
+    options: ParametrizedHostClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/review/schema-registry.api.md
+++ b/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/review/schema-registry.api.md
@@ -91,13 +91,13 @@ export interface SchemaProperties {
 
 // @public (undocumented)
 export class SchemaRegistryClient {
-    constructor(fullyQualifiedNamespace: string, credential: TokenCredential, options?: SchemaRegistryClientOptions);
+    constructor(fullyQualifiedNamespace: string, credential: TokenCredential, options?: SchemaRegistryClientOptionalParams);
     readonly pipeline: Pipeline;
     readonly schemaOperations: SchemaOperationsOperations;
 }
 
 // @public
-export interface SchemaRegistryClientOptions extends ClientOptions {
+export interface SchemaRegistryClientOptionalParams extends ClientOptions {
     apiVersion?: string;
 }
 

--- a/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createSchemaRegistry,
-  SchemaRegistryClientOptions,
+  SchemaRegistryClientOptionalParams,
   SchemaRegistryContext,
 } from "./schemaRegistryContext.js";

--- a/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/api/schemaRegistryContext.ts
+++ b/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/api/schemaRegistryContext.ts
@@ -7,7 +7,7 @@ import { SchemaRegistryContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface SchemaRegistryClientOptions extends ClientOptions {
+export interface SchemaRegistryClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -18,7 +18,7 @@ export { SchemaRegistryContext } from "../rest/index.js";
 export function createSchemaRegistry(
   fullyQualifiedNamespace: string,
   credential: TokenCredential,
-  options: SchemaRegistryClientOptions = {},
+  options: SchemaRegistryClientOptionalParams = {},
 ): SchemaRegistryContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   SchemaRegistryClient,
-  SchemaRegistryClientOptions,
+  SchemaRegistryClientOptionalParams,
 } from "./schemaRegistryClient.js";
 export {
   SchemaGroup,

--- a/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/schemaRegistryClient.ts
+++ b/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/schemaRegistryClient.ts
@@ -9,11 +9,11 @@ import {
 } from "./classic/schemaOperations/index.js";
 import {
   createSchemaRegistry,
-  SchemaRegistryClientOptions,
+  SchemaRegistryClientOptionalParams,
   SchemaRegistryContext,
 } from "./api/index.js";
 
-export { SchemaRegistryClientOptions } from "./api/schemaRegistryContext.js";
+export { SchemaRegistryClientOptionalParams } from "./api/schemaRegistryContext.js";
 
 export class SchemaRegistryClient {
   private _client: SchemaRegistryContext;
@@ -24,7 +24,7 @@ export class SchemaRegistryClient {
   constructor(
     fullyQualifiedNamespace: string,
     credential: TokenCredential,
-    options: SchemaRegistryClientOptions = {},
+    options: SchemaRegistryClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/review/widget_dpg.api.md
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/review/widget_dpg.api.md
@@ -125,14 +125,14 @@ export interface WidgetsDeleteWidgetOptionalParams extends OperationOptions {
 
 // @public (undocumented)
 export class WidgetServiceClient {
-    constructor(endpoint: string, options?: WidgetServiceClientOptions);
+    constructor(endpoint: string, options?: WidgetServiceClientOptionalParams);
     readonly budgets: BudgetsOperations;
     readonly pipeline: Pipeline;
     readonly widgets: WidgetsOperations;
 }
 
 // @public
-export interface WidgetServiceClientOptions extends ClientOptions {
+export interface WidgetServiceClientOptionalParams extends ClientOptions {
 }
 
 // @public

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/api/index.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createWidgetService,
-  WidgetServiceClientOptions,
+  WidgetServiceClientOptionalParams,
   WidgetServiceContext,
 } from "./widgetServiceContext.js";

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/api/widgetServiceContext.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/api/widgetServiceContext.ts
@@ -6,13 +6,13 @@ import { WidgetServiceContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface WidgetServiceClientOptions extends ClientOptions {}
+export interface WidgetServiceClientOptionalParams extends ClientOptions {}
 
 export { WidgetServiceContext } from "../rest/index.js";
 
 export function createWidgetService(
   endpoint: string,
-  options: WidgetServiceClientOptions = {},
+  options: WidgetServiceClientOptionalParams = {},
 ): WidgetServiceContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   WidgetServiceClient,
-  WidgetServiceClientOptions,
+  WidgetServiceClientOptionalParams,
 } from "./widgetServiceClient.js";
 export { restorePoller, RestorePollerOptions } from "./restorePollerHelpers.js";
 export {

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/widgetServiceClient.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/widgetServiceClient.ts
@@ -12,18 +12,21 @@ import {
 } from "./classic/budgets/index.js";
 import {
   createWidgetService,
-  WidgetServiceClientOptions,
+  WidgetServiceClientOptionalParams,
   WidgetServiceContext,
 } from "./api/index.js";
 
-export { WidgetServiceClientOptions } from "./api/widgetServiceContext.js";
+export { WidgetServiceClientOptionalParams } from "./api/widgetServiceContext.js";
 
 export class WidgetServiceClient {
   private _client: WidgetServiceContext;
   /** The pipeline used by this client to make requests */
   public readonly pipeline: Pipeline;
 
-  constructor(endpoint: string, options: WidgetServiceClientOptions = {}) {
+  constructor(
+    endpoint: string,
+    options: WidgetServiceClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/src/modular/buildClassicalClient.ts
+++ b/packages/typespec-ts/src/modular/buildClassicalClient.ts
@@ -49,7 +49,7 @@ export function buildClassicalClient(
   );
 
   clientFile.addExportDeclaration({
-    namedExports: [`${classicalClientName}Options`],
+    namedExports: [`${classicalClientName}OptionalParams`],
     moduleSpecifier: `./api/${normalizeName(
       modularClientName,
       NameType.File

--- a/packages/typespec-ts/src/modular/buildClientContext.ts
+++ b/packages/typespec-ts/src/modular/buildClientContext.ts
@@ -44,7 +44,7 @@ export function buildClientContext(
   });
 
   clientContextFile.addInterface({
-    name: `${name}ClientOptions`,
+    name: `${name}ClientOptionalParams`,
     isExported: true,
     extends: ["ClientOptions"],
     properties: client.parameters

--- a/packages/typespec-ts/src/modular/buildRootIndex.ts
+++ b/packages/typespec-ts/src/modular/buildRootIndex.ts
@@ -99,7 +99,7 @@ function exportClassicalClient(
 ) {
   const clientName = `${getClientName(client)}Client`;
   indexFile.addExportDeclaration({
-    namedExports: [clientName, `${clientName}Options`],
+    namedExports: [clientName, `${clientName}OptionalParams`],
     moduleSpecifier: `./${
       subfolder !== "" && !isSubClient ? subfolder + "/" : ""
     }${normalizeName(clientName, NameType.File)}.js`

--- a/packages/typespec-ts/src/modular/helpers/clientHelpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/clientHelpers.ts
@@ -21,7 +21,7 @@ export function getClientParameters(
   const name = getClientName(client);
   const optionsParam = {
     name: "options",
-    type: `${name}ClientOptions`,
+    type: `${name}ClientOptionalParams`,
     initializer: "{}"
   };
 

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/api-key/src/api/apiKeyContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/api-key/src/api/apiKeyContext.ts
@@ -7,14 +7,14 @@ import { ApiKeyContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ApiKeyClientOptions extends ClientOptions {}
+export interface ApiKeyClientOptionalParams extends ClientOptions {}
 
 export { ApiKeyContext } from "../rest/index.js";
 
 /** Illustrates clients generated with ApiKey authentication. */
 export function createApiKey(
   credential: KeyCredential,
-  options: ApiKeyClientOptions = {},
+  options: ApiKeyClientOptionalParams = {},
 ): ApiKeyContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/api-key/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/api-key/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createApiKey,
-  ApiKeyClientOptions,
+  ApiKeyClientOptionalParams,
   ApiKeyContext,
 } from "./apiKeyContext.js";
 export { valid, invalid } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/api-key/src/apiKeyClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/api-key/src/apiKeyClient.ts
@@ -9,13 +9,13 @@ import {
 } from "./models/options.js";
 import {
   createApiKey,
-  ApiKeyClientOptions,
+  ApiKeyClientOptionalParams,
   ApiKeyContext,
   valid,
   invalid,
 } from "./api/index.js";
 
-export { ApiKeyClientOptions } from "./api/apiKeyContext.js";
+export { ApiKeyClientOptionalParams } from "./api/apiKeyContext.js";
 
 export class ApiKeyClient {
   private _client: ApiKeyContext;
@@ -23,7 +23,10 @@ export class ApiKeyClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates clients generated with ApiKey authentication. */
-  constructor(credential: KeyCredential, options: ApiKeyClientOptions = {}) {
+  constructor(
+    credential: KeyCredential,
+    options: ApiKeyClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/api-key/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/api-key/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { ApiKeyClient, ApiKeyClientOptions } from "./apiKeyClient.js";
+export { ApiKeyClient, ApiKeyClientOptionalParams } from "./apiKeyClient.js";
 export {
   InvalidAuth,
   ValidOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/http/custom/src/api/customContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/http/custom/src/api/customContext.ts
@@ -7,14 +7,14 @@ import { CustomContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface CustomClientOptions extends ClientOptions {}
+export interface CustomClientOptionalParams extends ClientOptions {}
 
 export { CustomContext } from "../rest/index.js";
 
 /** Illustrates clients generated with generic HTTP auth. */
 export function createCustom(
   credential: KeyCredential,
-  options: CustomClientOptions = {},
+  options: CustomClientOptionalParams = {},
 ): CustomContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/http/custom/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/http/custom/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createCustom,
-  CustomClientOptions,
+  CustomClientOptionalParams,
   CustomContext,
 } from "./customContext.js";
 export { valid, invalid } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/http/custom/src/customClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/http/custom/src/customClient.ts
@@ -9,13 +9,13 @@ import {
 } from "./models/options.js";
 import {
   createCustom,
-  CustomClientOptions,
+  CustomClientOptionalParams,
   CustomContext,
   valid,
   invalid,
 } from "./api/index.js";
 
-export { CustomClientOptions } from "./api/customContext.js";
+export { CustomClientOptionalParams } from "./api/customContext.js";
 
 export class CustomClient {
   private _client: CustomContext;
@@ -23,7 +23,10 @@ export class CustomClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates clients generated with generic HTTP auth. */
-  constructor(credential: KeyCredential, options: CustomClientOptions = {}) {
+  constructor(
+    credential: KeyCredential,
+    options: CustomClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/http/custom/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/http/custom/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { CustomClient, CustomClientOptions } from "./customClient.js";
+export { CustomClient, CustomClientOptionalParams } from "./customClient.js";
 export {
   InvalidAuth,
   ValidOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createOAuth2,
-  OAuth2ClientOptions,
+  OAuth2ClientOptionalParams,
   OAuth2Context,
 } from "./oAuth2Context.js";
 export { valid, invalid } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/api/oAuth2Context.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/api/oAuth2Context.ts
@@ -7,14 +7,14 @@ import { OAuth2Context } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface OAuth2ClientOptions extends ClientOptions {}
+export interface OAuth2ClientOptionalParams extends ClientOptions {}
 
 export { OAuth2Context } from "../rest/index.js";
 
 /** Illustrates clients generated with OAuth2 authentication. */
 export function createOAuth2(
   credential: TokenCredential,
-  options: OAuth2ClientOptions = {},
+  options: OAuth2ClientOptionalParams = {},
 ): OAuth2Context {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { OAuth2Client, OAuth2ClientOptions } from "./oAuth2Client.js";
+export { OAuth2Client, OAuth2ClientOptionalParams } from "./oAuth2Client.js";
 export {
   InvalidAuth,
   ValidOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/oAuth2Client.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/oAuth2Client.ts
@@ -9,13 +9,13 @@ import {
 } from "./models/options.js";
 import {
   createOAuth2,
-  OAuth2ClientOptions,
+  OAuth2ClientOptionalParams,
   OAuth2Context,
   valid,
   invalid,
 } from "./api/index.js";
 
-export { OAuth2ClientOptions } from "./api/oAuth2Context.js";
+export { OAuth2ClientOptionalParams } from "./api/oAuth2Context.js";
 
 export class OAuth2Client {
   private _client: OAuth2Context;
@@ -23,7 +23,10 @@ export class OAuth2Client {
   public readonly pipeline: Pipeline;
 
   /** Illustrates clients generated with OAuth2 authentication. */
-  constructor(credential: TokenCredential, options: OAuth2ClientOptions = {}) {
+  constructor(
+    credential: TokenCredential,
+    options: OAuth2ClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/union/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/union/src/api/index.ts
@@ -4,6 +4,6 @@
 export { validKey, validToken } from "./operations.js";
 export {
   createUnion,
-  UnionClientOptions,
+  UnionClientOptionalParams,
   UnionContext,
 } from "./unionContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/union/src/api/unionContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/union/src/api/unionContext.ts
@@ -7,14 +7,14 @@ import { UnionContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface UnionClientOptions extends ClientOptions {}
+export interface UnionClientOptionalParams extends ClientOptions {}
 
 export { UnionContext } from "../rest/index.js";
 
 /** Illustrates clients generated with ApiKey and OAuth2 authentication. */
 export function createUnion(
   credential: KeyCredential | TokenCredential,
-  options: UnionClientOptions = {},
+  options: UnionClientOptionalParams = {},
 ): UnionContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/union/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/union/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { UnionClient, UnionClientOptions } from "./unionClient.js";
+export { UnionClient, UnionClientOptionalParams } from "./unionClient.js";
 export {
   ValidKeyOptionalParams,
   ValidTokenOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/union/src/unionClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/union/src/unionClient.ts
@@ -7,7 +7,7 @@ import {
   validKey,
   validToken,
   createUnion,
-  UnionClientOptions,
+  UnionClientOptionalParams,
   UnionContext,
 } from "./api/index.js";
 import {
@@ -15,7 +15,7 @@ import {
   ValidTokenOptionalParams,
 } from "./models/options.js";
 
-export { UnionClientOptions } from "./api/unionContext.js";
+export { UnionClientOptionalParams } from "./api/unionContext.js";
 
 export class UnionClient {
   private _client: UnionContext;
@@ -25,7 +25,7 @@ export class UnionClient {
   /** Illustrates clients generated with ApiKey and OAuth2 authentication. */
   constructor(
     credential: KeyCredential | TokenCredential,
-    options: UnionClientOptions = {},
+    options: UnionClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/access/src/accessClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/access/src/accessClient.ts
@@ -25,7 +25,7 @@ import {
 } from "./models/options.js";
 import {
   createAccess,
-  AccessClientOptions,
+  AccessClientOptionalParams,
   AccessContext,
   noDecoratorInPublic,
   publicDecoratorInPublic,
@@ -38,7 +38,7 @@ import {
   discriminator,
 } from "./api/index.js";
 
-export { AccessClientOptions } from "./api/accessContext.js";
+export { AccessClientOptionalParams } from "./api/accessContext.js";
 
 export class AccessClient {
   private _client: AccessContext;
@@ -46,7 +46,7 @@ export class AccessClient {
   public readonly pipeline: Pipeline;
 
   /** Test for internal decorator. */
-  constructor(options: AccessClientOptions = {}) {
+  constructor(options: AccessClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/access/src/api/accessContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/access/src/api/accessContext.ts
@@ -6,12 +6,14 @@ import { AccessContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface AccessClientOptions extends ClientOptions {}
+export interface AccessClientOptionalParams extends ClientOptions {}
 
 export { AccessContext } from "../rest/index.js";
 
 /** Test for internal decorator. */
-export function createAccess(options: AccessClientOptions = {}): AccessContext {
+export function createAccess(
+  options: AccessClientOptionalParams = {},
+): AccessContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/access/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/access/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createAccess,
-  AccessClientOptions,
+  AccessClientOptionalParams,
   AccessContext,
 } from "./accessContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/access/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/access/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { AccessClient, AccessClientOptions } from "./accessClient.js";
+export { AccessClient, AccessClientOptionalParams } from "./accessClient.js";
 export {
   BaseModel,
   OuterModel,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/api/index.ts
@@ -8,6 +8,6 @@ export {
 } from "./operations.js";
 export {
   createUsage,
-  UsageClientOptions,
+  UsageClientOptionalParams,
   UsageContext,
 } from "./usageContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/api/usageContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/api/usageContext.ts
@@ -6,12 +6,14 @@ import { UsageContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface UsageClientOptions extends ClientOptions {}
+export interface UsageClientOptionalParams extends ClientOptions {}
 
 export { UsageContext } from "../rest/index.js";
 
 /** Test for internal decorator. */
-export function createUsage(options: UsageClientOptions = {}): UsageContext {
+export function createUsage(
+  options: UsageClientOptionalParams = {},
+): UsageContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { UsageClient, UsageClientOptions } from "./usageClient.js";
+export { UsageClient, UsageClientOptionalParams } from "./usageClient.js";
 export {
   InputModel,
   OutputModel,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/usageClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/usageClient.ts
@@ -13,11 +13,11 @@ import {
   outputToInputOutput,
   modelInReadOnlyProperty,
   createUsage,
-  UsageClientOptions,
+  UsageClientOptionalParams,
   UsageContext,
 } from "./api/index.js";
 
-export { UsageClientOptions } from "./api/usageContext.js";
+export { UsageClientOptionalParams } from "./api/usageContext.js";
 
 export class UsageClient {
   private _client: UsageContext;
@@ -25,7 +25,7 @@ export class UsageClient {
   public readonly pipeline: Pipeline;
 
   /** Test for internal decorator. */
-  constructor(options: UsageClientOptions = {}) {
+  constructor(options: UsageClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/api/basicContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/api/basicContext.ts
@@ -6,7 +6,7 @@ import { BasicContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface BasicClientOptions extends ClientOptions {
+export interface BasicClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -14,7 +14,9 @@ export interface BasicClientOptions extends ClientOptions {
 export { BasicContext } from "../rest/index.js";
 
 /** Illustrates bodies templated with Azure Core */
-export function createBasic(options: BasicClientOptions = {}): BasicContext {
+export function createBasic(
+  options: BasicClientOptionalParams = {},
+): BasicContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createBasic,
-  BasicClientOptions,
+  BasicClientOptionalParams,
   BasicContext,
 } from "./basicContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/basicClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/basicClient.ts
@@ -24,7 +24,7 @@ import {
 import { PagedAsyncIterableIterator } from "./models/pagingTypes.js";
 import {
   createBasic,
-  BasicClientOptions,
+  BasicClientOptionalParams,
   BasicContext,
   createOrUpdate,
   createOrReplace,
@@ -39,7 +39,7 @@ import {
   listSecondItem,
 } from "./api/index.js";
 
-export { BasicClientOptions } from "./api/basicContext.js";
+export { BasicClientOptionalParams } from "./api/basicContext.js";
 
 export class BasicClient {
   private _client: BasicContext;
@@ -47,7 +47,7 @@ export class BasicClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates bodies templated with Azure Core */
-  constructor(options: BasicClientOptions = {}) {
+  constructor(options: BasicClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { BasicClient, BasicClientOptions } from "./basicClient.js";
+export { BasicClient, BasicClientOptionalParams } from "./basicClient.js";
 export {
   User,
   UserOrder,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/api/index.ts
@@ -2,4 +2,8 @@
 // Licensed under the MIT license.
 
 export { longRunningRpc } from "./operations.js";
-export { createRpc, RpcClientOptions, RpcContext } from "./rpcContext.js";
+export {
+  createRpc,
+  RpcClientOptionalParams,
+  RpcContext,
+} from "./rpcContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/api/rpcContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/api/rpcContext.ts
@@ -6,7 +6,7 @@ import { RpcContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface RpcClientOptions extends ClientOptions {
+export interface RpcClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -14,7 +14,7 @@ export interface RpcClientOptions extends ClientOptions {
 export { RpcContext } from "../rest/index.js";
 
 /** Illustrates bodies templated with Azure Core with long-running RPC operation */
-export function createRpc(options: RpcClientOptions = {}): RpcContext {
+export function createRpc(options: RpcClientOptionalParams = {}): RpcContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { RpcClient, RpcClientOptions } from "./rpcClient.js";
+export { RpcClient, RpcClientOptionalParams } from "./rpcClient.js";
 export { restorePoller, RestorePollerOptions } from "./restorePollerHelpers.js";
 export {
   GenerationOptions,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/rpcClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/rpcClient.ts
@@ -8,11 +8,11 @@ import { LongRunningRpcOptionalParams } from "./models/options.js";
 import {
   longRunningRpc,
   createRpc,
-  RpcClientOptions,
+  RpcClientOptionalParams,
   RpcContext,
 } from "./api/index.js";
 
-export { RpcClientOptions } from "./api/rpcContext.js";
+export { RpcClientOptionalParams } from "./api/rpcContext.js";
 
 export class RpcClient {
   private _client: RpcContext;
@@ -20,7 +20,7 @@ export class RpcClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates bodies templated with Azure Core with long-running RPC operation */
-  constructor(options: RpcClientOptions = {}) {
+  constructor(options: RpcClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/api/index.ts
@@ -4,6 +4,6 @@
 export { createOrReplace, $delete, $export } from "./operations.js";
 export {
   createStandard,
-  StandardClientOptions,
+  StandardClientOptionalParams,
   StandardContext,
 } from "./standardContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/api/standardContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/api/standardContext.ts
@@ -6,7 +6,7 @@ import { StandardContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface StandardClientOptions extends ClientOptions {
+export interface StandardClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -15,7 +15,7 @@ export { StandardContext } from "../rest/index.js";
 
 /** Illustrates bodies templated with Azure Core with long-running operation */
 export function createStandard(
-  options: StandardClientOptions = {},
+  options: StandardClientOptionalParams = {},
 ): StandardContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { StandardClient, StandardClientOptions } from "./standardClient.js";
+export {
+  StandardClient,
+  StandardClientOptionalParams,
+} from "./standardClient.js";
 export { restorePoller, RestorePollerOptions } from "./restorePollerHelpers.js";
 export {
   User,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/standardClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/standardClient.ts
@@ -14,11 +14,11 @@ import {
   $delete,
   $export,
   createStandard,
-  StandardClientOptions,
+  StandardClientOptionalParams,
   StandardContext,
 } from "./api/index.js";
 
-export { StandardClientOptions } from "./api/standardContext.js";
+export { StandardClientOptionalParams } from "./api/standardContext.js";
 
 export class StandardClient {
   private _client: StandardContext;
@@ -26,7 +26,7 @@ export class StandardClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates bodies templated with Azure Core with long-running operation */
-  constructor(options: StandardClientOptions = {}) {
+  constructor(options: StandardClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/api/index.ts
@@ -4,6 +4,6 @@
 export { get, put, post, header, query } from "./operations.js";
 export {
   createScalar,
-  ScalarClientOptions,
+  ScalarClientOptionalParams,
   ScalarContext,
 } from "./scalarContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/api/scalarContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/api/scalarContext.ts
@@ -6,11 +6,13 @@ import { ScalarContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ScalarClientOptions extends ClientOptions {}
+export interface ScalarClientOptionalParams extends ClientOptions {}
 
 export { ScalarContext } from "../rest/index.js";
 
-export function createScalar(options: ScalarClientOptions = {}): ScalarContext {
+export function createScalar(
+  options: ScalarClientOptionalParams = {},
+): ScalarContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { ScalarClient, ScalarClientOptions } from "./scalarClient.js";
+export { ScalarClient, ScalarClientOptionalParams } from "./scalarClient.js";
 export {
   AzureLocationModel,
   Versions,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/scalarClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/scalarClient.ts
@@ -17,18 +17,18 @@ import {
   header,
   query,
   createScalar,
-  ScalarClientOptions,
+  ScalarClientOptionalParams,
   ScalarContext,
 } from "./api/index.js";
 
-export { ScalarClientOptions } from "./api/scalarContext.js";
+export { ScalarClientOptionalParams } from "./api/scalarContext.js";
 
 export class ScalarClient {
   private _client: ScalarContext;
   /** The pipeline used by this client to make requests */
   public readonly pipeline: Pipeline;
 
-  constructor(options: ScalarClientOptions = {}) {
+  constructor(options: ScalarClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/api/index.ts
@@ -4,6 +4,6 @@
 export { smokeTest, repeatableAction } from "./operations.js";
 export {
   createTraits,
-  TraitsClientOptions,
+  TraitsClientOptionalParams,
   TraitsContext,
 } from "./traitsContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/api/traitsContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/api/traitsContext.ts
@@ -6,7 +6,7 @@ import { TraitsContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface TraitsClientOptions extends ClientOptions {
+export interface TraitsClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -14,7 +14,9 @@ export interface TraitsClientOptions extends ClientOptions {
 export { TraitsContext } from "../rest/index.js";
 
 /** Illustrates Azure Core operation customizations by traits */
-export function createTraits(options: TraitsClientOptions = {}): TraitsContext {
+export function createTraits(
+  options: TraitsClientOptionalParams = {},
+): TraitsContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { TraitsClient, TraitsClientOptions } from "./traitsClient.js";
+export { TraitsClient, TraitsClientOptionalParams } from "./traitsClient.js";
 export {
   User,
   UserActionParam,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/traitsClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/traitsClient.ts
@@ -11,11 +11,11 @@ import {
   smokeTest,
   repeatableAction,
   createTraits,
-  TraitsClientOptions,
+  TraitsClientOptionalParams,
   TraitsContext,
 } from "./api/index.js";
 
-export { TraitsClientOptions } from "./api/traitsContext.js";
+export { TraitsClientOptionalParams } from "./api/traitsContext.js";
 
 export class TraitsClient {
   private _client: TraitsContext;
@@ -23,7 +23,7 @@ export class TraitsClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates Azure Core operation customizations by traits */
-  constructor(options: TraitsClientOptions = {}) {
+  constructor(options: TraitsClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createResources,
-  ResourcesClientOptions,
+  ResourcesClientOptionalParams,
   ResourcesContext,
 } from "./resourcesContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/api/resourcesContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/api/resourcesContext.ts
@@ -6,7 +6,7 @@ import { ResourcesContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ResourcesClientOptions extends ClientOptions {
+export interface ResourcesClientOptionalParams extends ClientOptions {
   /** The API version to use for this operation. */
   apiVersion?: string;
 }
@@ -15,7 +15,7 @@ export { ResourcesContext } from "../rest/index.js";
 
 /** Arm Resource Provider management API. */
 export function createResources(
-  options: ResourcesClientOptions = {},
+  options: ResourcesClientOptionalParams = {},
 ): ResourcesContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { ResourcesClient, ResourcesClientOptions } from "./resourcesClient.js";
+export {
+  ResourcesClient,
+  ResourcesClientOptionalParams,
+} from "./resourcesClient.js";
 export { restorePoller, RestorePollerOptions } from "./restorePollerHelpers.js";
 export {
   Resource,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/resourcesClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/resourcesClient.ts
@@ -12,11 +12,11 @@ import {
 } from "./classic/nestedProxyResources/index.js";
 import {
   createResources,
-  ResourcesClientOptions,
+  ResourcesClientOptionalParams,
   ResourcesContext,
 } from "./api/index.js";
 
-export { ResourcesClientOptions } from "./api/resourcesContext.js";
+export { ResourcesClientOptionalParams } from "./api/resourcesContext.js";
 
 export class ResourcesClient {
   private _client: ResourcesContext;
@@ -24,7 +24,10 @@ export class ResourcesClient {
   public readonly pipeline: Pipeline;
 
   /** Arm Resource Provider management API. */
-  constructor(subscriptionId: string, options: ResourcesClientOptions = {}) {
+  constructor(
+    subscriptionId: string,
+    options: ResourcesClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/api/index.ts
@@ -4,6 +4,6 @@
 export { get } from "./operations.js";
 export {
   createXmsRequestId,
-  XmsRequestIdClientOptions,
+  XmsRequestIdClientOptionalParams,
   XmsRequestIdClientContext,
 } from "./xmsRequestIdContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/api/xmsRequestIdContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/api/xmsRequestIdContext.ts
@@ -6,13 +6,13 @@ import { XmsRequestIdClientContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface XmsRequestIdClientOptions extends ClientOptions {}
+export interface XmsRequestIdClientOptionalParams extends ClientOptions {}
 
 export { XmsRequestIdClientContext } from "../rest/index.js";
 
 /** Azure client request id header configurations. */
 export function createXmsRequestId(
-  options: XmsRequestIdClientOptions = {},
+  options: XmsRequestIdClientOptionalParams = {},
 ): XmsRequestIdClientContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/index.ts
@@ -3,6 +3,6 @@
 
 export {
   XmsRequestIdClient,
-  XmsRequestIdClientOptions,
+  XmsRequestIdClientOptionalParams,
 } from "./xmsRequestIdClient.js";
 export { GetOptionalParams } from "./models/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/xmsRequestIdClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/xmsRequestIdClient.ts
@@ -5,12 +5,12 @@ import { Pipeline } from "@azure/core-rest-pipeline";
 import {
   get,
   createXmsRequestId,
-  XmsRequestIdClientOptions,
+  XmsRequestIdClientOptionalParams,
   XmsRequestIdClientContext,
 } from "./api/index.js";
 import { GetOptionalParams } from "./models/options.js";
 
-export { XmsRequestIdClientOptions } from "./api/xmsRequestIdContext.js";
+export { XmsRequestIdClientOptionalParams } from "./api/xmsRequestIdContext.js";
 
 export class XmsRequestIdClient {
   private _client: XmsRequestIdClientContext;
@@ -18,7 +18,7 @@ export class XmsRequestIdClient {
   public readonly pipeline: Pipeline;
 
   /** Azure client request id header configurations. */
-  constructor(options: XmsRequestIdClientOptions = {}) {
+  constructor(options: XmsRequestIdClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createNaming,
-  NamingClientOptions,
+  NamingClientOptionalParams,
   NamingContext,
 } from "./namingContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/api/namingContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/api/namingContext.ts
@@ -6,12 +6,14 @@ import { NamingContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface NamingClientOptions extends ClientOptions {}
+export interface NamingClientOptionalParams extends ClientOptions {}
 
 export { NamingContext } from "../rest/index.js";
 
 /** Describe changing names of types in a client with `@clientName` */
-export function createNaming(options: NamingClientOptions = {}): NamingContext {
+export function createNaming(
+  options: NamingClientOptionalParams = {},
+): NamingContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { NamingClient, NamingClientOptions } from "./namingClient.js";
+export { NamingClient, NamingClientOptionalParams } from "./namingClient.js";
 export {
   ClientNameModel,
   LanguageClientNameModel,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/namingClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/namingClient.ts
@@ -26,7 +26,7 @@ import {
 } from "./classic/unionEnum/index.js";
 import {
   createNaming,
-  NamingClientOptions,
+  NamingClientOptionalParams,
   NamingContext,
   clientName,
   parameter,
@@ -37,7 +37,7 @@ import {
   response,
 } from "./api/index.js";
 
-export { NamingClientOptions } from "./api/namingContext.js";
+export { NamingClientOptionalParams } from "./api/namingContext.js";
 
 export class NamingClient {
   private _client: NamingContext;
@@ -45,7 +45,7 @@ export class NamingClient {
   public readonly pipeline: Pipeline;
 
   /** Describe changing names of types in a client with `@clientName` */
-  constructor(options: NamingClientOptions = {}) {
+  constructor(options: NamingClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/index.ts
@@ -4,6 +4,6 @@
 export { one, two } from "./operations.js";
 export {
   createService,
-  ServiceClientOptions,
+  ServiceClientOptionalParams,
   ServiceContext,
 } from "./serviceContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/serviceContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/serviceContext.ts
@@ -7,7 +7,7 @@ import { ServiceContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ServiceClientOptions extends ClientOptions {}
+export interface ServiceClientOptionalParams extends ClientOptions {}
 
 export { ServiceContext } from "../rest/index.js";
 
@@ -23,7 +23,7 @@ export { ServiceContext } from "../rest/index.js";
 export function createService(
   endpointParam: string,
   clientParam: ClientType,
-  options: ServiceClientOptions = {},
+  options: ServiceClientOptionalParams = {},
 ): ServiceContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { ServiceClient, ServiceClientOptions } from "./serviceClient.js";
+export { ServiceClient, ServiceClientOptionalParams } from "./serviceClient.js";
 export {
   ClientType,
   OneOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/serviceClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/serviceClient.ts
@@ -12,11 +12,11 @@ import {
   one,
   two,
   createService,
-  ServiceClientOptions,
+  ServiceClientOptionalParams,
   ServiceContext,
 } from "./api/index.js";
 
-export { ServiceClientOptions } from "./api/serviceContext.js";
+export { ServiceClientOptionalParams } from "./api/serviceContext.js";
 
 export class ServiceClient {
   private _client: ServiceContext;
@@ -35,7 +35,7 @@ export class ServiceClient {
   constructor(
     endpointParam: string,
     clientParam: ClientType,
-    options: ServiceClientOptions = {},
+    options: ServiceClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/aClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/aClient.ts
@@ -10,14 +10,14 @@ import {
 } from "./models/options.js";
 import {
   createA,
-  AClientOptions,
+  AClientOptionalParams,
   ServiceContext,
   renamedOne,
   renamedThree,
   renamedFive,
 } from "./api/index.js";
 
-export { AClientOptions } from "./api/aContext.js";
+export { AClientOptionalParams } from "./api/aContext.js";
 
 export class AClient {
   private _client: ServiceContext;
@@ -27,7 +27,7 @@ export class AClient {
   constructor(
     endpointParam: string,
     clientParam: ClientType,
-    options: AClientOptions = {},
+    options: AClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/api/aContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/api/aContext.ts
@@ -7,14 +7,14 @@ import { ServiceContext } from "../../rest/index.js";
 import getClient from "../../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface AClientOptions extends ClientOptions {}
+export interface AClientOptionalParams extends ClientOptions {}
 
 export { ServiceContext } from "../../rest/index.js";
 
 export function createA(
   endpointParam: string,
   clientParam: ClientType,
-  options: AClientOptions = {},
+  options: AClientOptionalParams = {},
 ): ServiceContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/api/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { createA, AClientOptions, ServiceContext } from "./aContext.js";
+export { createA, AClientOptionalParams, ServiceContext } from "./aContext.js";
 export { renamedOne, renamedThree, renamedFive } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { AClient, AClientOptions } from "./aClient.js";
+export { AClient, AClientOptionalParams } from "./aClient.js";
 export {
   ClientType,
   RenamedOneOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/api/bContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/api/bContext.ts
@@ -7,14 +7,14 @@ import { ServiceContext } from "../../rest/index.js";
 import getClient from "../../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface BClientOptions extends ClientOptions {}
+export interface BClientOptionalParams extends ClientOptions {}
 
 export { ServiceContext } from "../../rest/index.js";
 
 export function createB(
   endpointParam: string,
   clientParam: ClientType,
-  options: BClientOptions = {},
+  options: BClientOptionalParams = {},
 ): ServiceContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/api/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { createB, BClientOptions, ServiceContext } from "./bContext.js";
+export { createB, BClientOptionalParams, ServiceContext } from "./bContext.js";
 export { renamedTwo, renamedFour, renamedSix } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/bClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/bClient.ts
@@ -10,14 +10,14 @@ import {
 } from "./models/options.js";
 import {
   createB,
-  BClientOptions,
+  BClientOptionalParams,
   ServiceContext,
   renamedTwo,
   renamedFour,
   renamedSix,
 } from "./api/index.js";
 
-export { BClientOptions } from "./api/bContext.js";
+export { BClientOptionalParams } from "./api/bContext.js";
 
 export class BClient {
   private _client: ServiceContext;
@@ -27,7 +27,7 @@ export class BClient {
   constructor(
     endpointParam: string,
     clientParam: ClientType,
-    options: BClientOptions = {},
+    options: BClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { BClient, BClientOptions } from "./bClient.js";
+export { BClient, BClientOptionalParams } from "./bClient.js";
 export {
   ClientType,
   RenamedTwoOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/index.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { AClient, AClientOptions } from "./a/aClient.js";
+export { AClient, AClientOptionalParams } from "./a/aClient.js";
 export {
   ClientType,
   RenamedOneOptionalParams,
   RenamedThreeOptionalParams,
   RenamedFiveOptionalParams,
 } from "./a/models/index.js";
-export { BClient, BClientOptions } from "./b/bClient.js";
+export { BClient, BClientOptionalParams } from "./b/bClient.js";
 export {
   ClientType as BClientClientType,
   RenamedTwoOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/api/index.ts
@@ -4,6 +4,6 @@
 export { renamedOne, renamedThree, renamedFive } from "./operations.js";
 export {
   createRenamedOperation,
-  RenamedOperationClientOptions,
+  RenamedOperationClientOptionalParams,
   ServiceContext,
 } from "./renamedOperationContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/api/renamedOperationContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/api/renamedOperationContext.ts
@@ -7,14 +7,14 @@ import { ServiceContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface RenamedOperationClientOptions extends ClientOptions {}
+export interface RenamedOperationClientOptionalParams extends ClientOptions {}
 
 export { ServiceContext } from "../rest/index.js";
 
 export function createRenamedOperation(
   endpointParam: string,
   clientParam: ClientType,
-  options: RenamedOperationClientOptions = {},
+  options: RenamedOperationClientOptionalParams = {},
 ): ServiceContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   RenamedOperationClient,
-  RenamedOperationClientOptions,
+  RenamedOperationClientOptionalParams,
 } from "./renamedOperationClient.js";
 export {
   ClientType,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/renamedOperationClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/renamedOperationClient.ts
@@ -14,11 +14,11 @@ import {
   renamedThree,
   renamedFive,
   createRenamedOperation,
-  RenamedOperationClientOptions,
+  RenamedOperationClientOptionalParams,
   ServiceContext,
 } from "./api/index.js";
 
-export { RenamedOperationClientOptions } from "./api/renamedOperationContext.js";
+export { RenamedOperationClientOptionalParams } from "./api/renamedOperationContext.js";
 
 export class RenamedOperationClient {
   private _client: ServiceContext;
@@ -28,7 +28,7 @@ export class RenamedOperationClient {
   constructor(
     endpointParam: string,
     clientParam: ClientType,
-    options: RenamedOperationClientOptions = {},
+    options: RenamedOperationClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createTwoOperationGroup,
-  TwoOperationGroupClientOptions,
+  TwoOperationGroupClientOptionalParams,
   ServiceContext,
 } from "./twoOperationGroupContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/api/twoOperationGroupContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/api/twoOperationGroupContext.ts
@@ -7,14 +7,14 @@ import { ServiceContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface TwoOperationGroupClientOptions extends ClientOptions {}
+export interface TwoOperationGroupClientOptionalParams extends ClientOptions {}
 
 export { ServiceContext } from "../rest/index.js";
 
 export function createTwoOperationGroup(
   endpointParam: string,
   clientParam: ClientType,
-  options: TwoOperationGroupClientOptions = {},
+  options: TwoOperationGroupClientOptionalParams = {},
 ): ServiceContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   TwoOperationGroupClient,
-  TwoOperationGroupClientOptions,
+  TwoOperationGroupClientOptionalParams,
 } from "./twoOperationGroupClient.js";
 export {
   ClientType,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/twoOperationGroupClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/twoOperationGroupClient.ts
@@ -13,11 +13,11 @@ import {
 } from "./classic/group2/index.js";
 import {
   createTwoOperationGroup,
-  TwoOperationGroupClientOptions,
+  TwoOperationGroupClientOptionalParams,
   ServiceContext,
 } from "./api/index.js";
 
-export { TwoOperationGroupClientOptions } from "./api/twoOperationGroupContext.js";
+export { TwoOperationGroupClientOptionalParams } from "./api/twoOperationGroupContext.js";
 
 export class TwoOperationGroupClient {
   private _client: ServiceContext;
@@ -27,7 +27,7 @@ export class TwoOperationGroupClient {
   constructor(
     endpointParam: string,
     clientParam: ClientType,
-    options: TwoOperationGroupClientOptions = {},
+    options: TwoOperationGroupClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/bytes/src/api/bytesContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/bytes/src/api/bytesContext.ts
@@ -6,12 +6,14 @@ import { BytesContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface BytesClientOptions extends ClientOptions {}
+export interface BytesClientOptionalParams extends ClientOptions {}
 
 export { BytesContext } from "../rest/index.js";
 
 /** Test for encode decorator on bytes. */
-export function createBytes(options: BytesClientOptions = {}): BytesContext {
+export function createBytes(
+  options: BytesClientOptionalParams = {},
+): BytesContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/bytes/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/bytes/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createBytes,
-  BytesClientOptions,
+  BytesClientOptionalParams,
   BytesContext,
 } from "./bytesContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/bytes/src/bytesClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/bytes/src/bytesClient.ts
@@ -19,9 +19,13 @@ import {
   getResponseBodyOperations,
   ResponseBodyOperations,
 } from "./classic/responseBody/index.js";
-import { createBytes, BytesClientOptions, BytesContext } from "./api/index.js";
+import {
+  createBytes,
+  BytesClientOptionalParams,
+  BytesContext,
+} from "./api/index.js";
 
-export { BytesClientOptions } from "./api/bytesContext.js";
+export { BytesClientOptionalParams } from "./api/bytesContext.js";
 
 export class BytesClient {
   private _client: BytesContext;
@@ -29,7 +33,7 @@ export class BytesClient {
   public readonly pipeline: Pipeline;
 
   /** Test for encode decorator on bytes. */
-  constructor(options: BytesClientOptions = {}) {
+  constructor(options: BytesClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/bytes/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/bytes/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { BytesClient, BytesClientOptions } from "./bytesClient.js";
+export { BytesClient, BytesClientOptionalParams } from "./bytesClient.js";
 export {
   DefaultBytesProperty,
   Base64BytesProperty,

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/datetime/src/api/datetimeContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/datetime/src/api/datetimeContext.ts
@@ -6,13 +6,13 @@ import { DatetimeContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface DatetimeClientOptions extends ClientOptions {}
+export interface DatetimeClientOptionalParams extends ClientOptions {}
 
 export { DatetimeContext } from "../rest/index.js";
 
 /** Test for encode decorator on datetime. */
 export function createDatetime(
-  options: DatetimeClientOptions = {},
+  options: DatetimeClientOptionalParams = {},
 ): DatetimeContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/datetime/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/datetime/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createDatetime,
-  DatetimeClientOptions,
+  DatetimeClientOptionalParams,
   DatetimeContext,
 } from "./datetimeContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/datetime/src/datetimeClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/datetime/src/datetimeClient.ts
@@ -17,11 +17,11 @@ import {
 } from "./classic/responseHeader/index.js";
 import {
   createDatetime,
-  DatetimeClientOptions,
+  DatetimeClientOptionalParams,
   DatetimeContext,
 } from "./api/index.js";
 
-export { DatetimeClientOptions } from "./api/datetimeContext.js";
+export { DatetimeClientOptionalParams } from "./api/datetimeContext.js";
 
 export class DatetimeClient {
   private _client: DatetimeContext;
@@ -29,7 +29,7 @@ export class DatetimeClient {
   public readonly pipeline: Pipeline;
 
   /** Test for encode decorator on datetime. */
-  constructor(options: DatetimeClientOptions = {}) {
+  constructor(options: DatetimeClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/datetime/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/datetime/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { DatetimeClient, DatetimeClientOptions } from "./datetimeClient.js";
+export {
+  DatetimeClient,
+  DatetimeClientOptionalParams,
+} from "./datetimeClient.js";
 export {
   DefaultDatetimeProperty,
   Rfc3339DatetimeProperty,

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/duration/src/api/durationContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/duration/src/api/durationContext.ts
@@ -6,13 +6,13 @@ import { DurationContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface DurationClientOptions extends ClientOptions {}
+export interface DurationClientOptionalParams extends ClientOptions {}
 
 export { DurationContext } from "../rest/index.js";
 
 /** Test for encode decorator on duration. */
 export function createDuration(
-  options: DurationClientOptions = {},
+  options: DurationClientOptionalParams = {},
 ): DurationContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/duration/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/duration/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createDuration,
-  DurationClientOptions,
+  DurationClientOptionalParams,
   DurationContext,
 } from "./durationContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/duration/src/durationClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/duration/src/durationClient.ts
@@ -13,11 +13,11 @@ import {
 } from "./classic/header/index.js";
 import {
   createDuration,
-  DurationClientOptions,
+  DurationClientOptionalParams,
   DurationContext,
 } from "./api/index.js";
 
-export { DurationClientOptions } from "./api/durationContext.js";
+export { DurationClientOptionalParams } from "./api/durationContext.js";
 
 export class DurationClient {
   private _client: DurationContext;
@@ -25,7 +25,7 @@ export class DurationClient {
   public readonly pipeline: Pipeline;
 
   /** Test for encode decorator on duration. */
-  constructor(options: DurationClientOptions = {}) {
+  constructor(options: DurationClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/encode/duration/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/encode/duration/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { DurationClient, DurationClientOptions } from "./durationClient.js";
+export {
+  DurationClient,
+  DurationClientOptionalParams,
+} from "./durationClient.js";
 export {
   DefaultDurationProperty,
   ISO8601DurationProperty,

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/basic/src/api/basicContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/basic/src/api/basicContext.ts
@@ -6,12 +6,14 @@ import { BasicContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface BasicClientOptions extends ClientOptions {}
+export interface BasicClientOptionalParams extends ClientOptions {}
 
 export { BasicContext } from "../rest/index.js";
 
 /** Test for basic parameters cases. */
-export function createBasic(options: BasicClientOptions = {}): BasicContext {
+export function createBasic(
+  options: BasicClientOptionalParams = {},
+): BasicContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/basic/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/basic/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createBasic,
-  BasicClientOptions,
+  BasicClientOptionalParams,
   BasicContext,
 } from "./basicContext.js";
 export { explicitBodySimple } from "./explicitBody/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/basic/src/basicClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/basic/src/basicClient.ts
@@ -10,9 +10,13 @@ import {
   getImplicitBodyOperations,
   ImplicitBodyOperations,
 } from "./classic/implicitBody/index.js";
-import { createBasic, BasicClientOptions, BasicContext } from "./api/index.js";
+import {
+  createBasic,
+  BasicClientOptionalParams,
+  BasicContext,
+} from "./api/index.js";
 
-export { BasicClientOptions } from "./api/basicContext.js";
+export { BasicClientOptionalParams } from "./api/basicContext.js";
 
 export class BasicClient {
   private _client: BasicContext;
@@ -20,7 +24,7 @@ export class BasicClient {
   public readonly pipeline: Pipeline;
 
   /** Test for basic parameters cases. */
-  constructor(options: BasicClientOptions = {}) {
+  constructor(options: BasicClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/basic/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/basic/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { BasicClient, BasicClientOptions } from "./basicClient.js";
+export { BasicClient, BasicClientOptionalParams } from "./basicClient.js";
 export {
   User,
   ExplicitBodySimpleOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/src/api/bodyOptionalityContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/src/api/bodyOptionalityContext.ts
@@ -6,13 +6,13 @@ import { BodyOptionalityContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface BodyOptionalityClientOptions extends ClientOptions {}
+export interface BodyOptionalityClientOptionalParams extends ClientOptions {}
 
 export { BodyOptionalityContext } from "../rest/index.js";
 
 /** Test describing optionality of the request body. */
 export function createBodyOptionality(
-  options: BodyOptionalityClientOptions = {},
+  options: BodyOptionalityClientOptionalParams = {},
 ): BodyOptionalityContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createBodyOptionality,
-  BodyOptionalityClientOptions,
+  BodyOptionalityClientOptionalParams,
   BodyOptionalityContext,
 } from "./bodyOptionalityContext.js";
 export { requiredExplicit, requiredImplicit } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/src/bodyOptionalityClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/src/bodyOptionalityClient.ts
@@ -13,13 +13,13 @@ import {
 } from "./classic/optionalExplicit/index.js";
 import {
   createBodyOptionality,
-  BodyOptionalityClientOptions,
+  BodyOptionalityClientOptionalParams,
   BodyOptionalityContext,
   requiredExplicit,
   requiredImplicit,
 } from "./api/index.js";
 
-export { BodyOptionalityClientOptions } from "./api/bodyOptionalityContext.js";
+export { BodyOptionalityClientOptionalParams } from "./api/bodyOptionalityContext.js";
 
 export class BodyOptionalityClient {
   private _client: BodyOptionalityContext;
@@ -27,7 +27,7 @@ export class BodyOptionalityClient {
   public readonly pipeline: Pipeline;
 
   /** Test describing optionality of the request body. */
-  constructor(options: BodyOptionalityClientOptions = {}) {
+  constructor(options: BodyOptionalityClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   BodyOptionalityClient,
-  BodyOptionalityClientOptions,
+  BodyOptionalityClientOptionalParams,
 } from "./bodyOptionalityClient.js";
 export {
   BodyModel,

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/collection-format/src/api/collectionFormatContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/collection-format/src/api/collectionFormatContext.ts
@@ -6,13 +6,13 @@ import { CollectionFormatContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface CollectionFormatClientOptions extends ClientOptions {}
+export interface CollectionFormatClientOptionalParams extends ClientOptions {}
 
 export { CollectionFormatContext } from "../rest/index.js";
 
 /** Test for collectionFormat. */
 export function createCollectionFormat(
-  options: CollectionFormatClientOptions = {},
+  options: CollectionFormatClientOptionalParams = {},
 ): CollectionFormatContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/collection-format/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/collection-format/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createCollectionFormat,
-  CollectionFormatClientOptions,
+  CollectionFormatClientOptionalParams,
   CollectionFormatContext,
 } from "./collectionFormatContext.js";
 export { headerCsv } from "./header/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/collection-format/src/collectionFormatClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/collection-format/src/collectionFormatClient.ts
@@ -9,11 +9,11 @@ import {
 } from "./classic/header/index.js";
 import {
   createCollectionFormat,
-  CollectionFormatClientOptions,
+  CollectionFormatClientOptionalParams,
   CollectionFormatContext,
 } from "./api/index.js";
 
-export { CollectionFormatClientOptions } from "./api/collectionFormatContext.js";
+export { CollectionFormatClientOptionalParams } from "./api/collectionFormatContext.js";
 
 export class CollectionFormatClient {
   private _client: CollectionFormatContext;
@@ -21,7 +21,7 @@ export class CollectionFormatClient {
   public readonly pipeline: Pipeline;
 
   /** Test for collectionFormat. */
-  constructor(options: CollectionFormatClientOptions = {}) {
+  constructor(options: CollectionFormatClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/collection-format/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/collection-format/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   CollectionFormatClient,
-  CollectionFormatClientOptions,
+  CollectionFormatClientOptionalParams,
 } from "./collectionFormatClient.js";
 export {
   QueryMultiOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createSpread,
-  SpreadClientOptions,
+  SpreadClientOptionalParams,
   SpreadContext,
 } from "./spreadContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/api/spreadContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/api/spreadContext.ts
@@ -6,12 +6,14 @@ import { SpreadContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface SpreadClientOptions extends ClientOptions {}
+export interface SpreadClientOptionalParams extends ClientOptions {}
 
 export { SpreadContext } from "../rest/index.js";
 
 /** Test for the spread operator. */
-export function createSpread(options: SpreadClientOptions = {}): SpreadContext {
+export function createSpread(
+  options: SpreadClientOptionalParams = {},
+): SpreadContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { SpreadClient, SpreadClientOptions } from "./spreadClient.js";
+export { SpreadClient, SpreadClientOptionalParams } from "./spreadClient.js";
 export {
   BodyParameter,
   CompositeRequestMix,

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/spreadClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/spreadClient.ts
@@ -6,11 +6,11 @@ import { getModelOperations, ModelOperations } from "./classic/model/index.js";
 import { getAliasOperations, AliasOperations } from "./classic/alias/index.js";
 import {
   createSpread,
-  SpreadClientOptions,
+  SpreadClientOptionalParams,
   SpreadContext,
 } from "./api/index.js";
 
-export { SpreadClientOptions } from "./api/spreadContext.js";
+export { SpreadClientOptionalParams } from "./api/spreadContext.js";
 
 export class SpreadClient {
   private _client: SpreadContext;
@@ -18,7 +18,7 @@ export class SpreadClient {
   public readonly pipeline: Pipeline;
 
   /** Test for the spread operator. */
-  constructor(options: SpreadClientOptions = {}) {
+  constructor(options: SpreadClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/content-negotiation/src/api/contentNegotiationContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/content-negotiation/src/api/contentNegotiationContext.ts
@@ -6,13 +6,13 @@ import { ContentNegotiationContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ContentNegotiationClientOptions extends ClientOptions {}
+export interface ContentNegotiationClientOptionalParams extends ClientOptions {}
 
 export { ContentNegotiationContext } from "../rest/index.js";
 
 /** Test describing optionality of the request body. */
 export function createContentNegotiation(
-  options: ContentNegotiationClientOptions = {},
+  options: ContentNegotiationClientOptionalParams = {},
 ): ContentNegotiationContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/content-negotiation/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/content-negotiation/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createContentNegotiation,
-  ContentNegotiationClientOptions,
+  ContentNegotiationClientOptionalParams,
   ContentNegotiationContext,
 } from "./contentNegotiationContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/content-negotiation/src/contentNegotiationClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/content-negotiation/src/contentNegotiationClient.ts
@@ -12,11 +12,11 @@ import {
 } from "./classic/differentBody/index.js";
 import {
   createContentNegotiation,
-  ContentNegotiationClientOptions,
+  ContentNegotiationClientOptionalParams,
   ContentNegotiationContext,
 } from "./api/index.js";
 
-export { ContentNegotiationClientOptions } from "./api/contentNegotiationContext.js";
+export { ContentNegotiationClientOptionalParams } from "./api/contentNegotiationContext.js";
 
 export class ContentNegotiationClient {
   private _client: ContentNegotiationContext;
@@ -24,7 +24,7 @@ export class ContentNegotiationClient {
   public readonly pipeline: Pipeline;
 
   /** Test describing optionality of the request body. */
-  constructor(options: ContentNegotiationClientOptions = {}) {
+  constructor(options: ContentNegotiationClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/content-negotiation/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/content-negotiation/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   ContentNegotiationClient,
-  ContentNegotiationClientOptions,
+  ContentNegotiationClientOptionalParams,
 } from "./contentNegotiationClient.js";
 export {
   PngImageAsJson,

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createMediaType,
-  MediaTypeClientOptions,
+  MediaTypeClientOptionalParams,
   MediaTypeContext,
 } from "./mediaTypeContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/api/mediaTypeContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/api/mediaTypeContext.ts
@@ -6,13 +6,13 @@ import { MediaTypeContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface MediaTypeClientOptions extends ClientOptions {}
+export interface MediaTypeClientOptionalParams extends ClientOptions {}
 
 export { MediaTypeContext } from "../rest/index.js";
 
 /** Test the payload with different media types and different types of the payload itself. */
 export function createMediaType(
-  options: MediaTypeClientOptions = {},
+  options: MediaTypeClientOptionalParams = {},
 ): MediaTypeContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { MediaTypeClient, MediaTypeClientOptions } from "./mediaTypeClient.js";
+export {
+  MediaTypeClient,
+  MediaTypeClientOptionalParams,
+} from "./mediaTypeClient.js";
 export {
   StringBodySendAsTextOptionalParams,
   StringBodyGetAsTextOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/mediaTypeClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/mediaTypeClient.ts
@@ -8,11 +8,11 @@ import {
 } from "./classic/stringBody/index.js";
 import {
   createMediaType,
-  MediaTypeClientOptions,
+  MediaTypeClientOptionalParams,
   MediaTypeContext,
 } from "./api/index.js";
 
-export { MediaTypeClientOptions } from "./api/mediaTypeContext.js";
+export { MediaTypeClientOptionalParams } from "./api/mediaTypeContext.js";
 
 export class MediaTypeClient {
   private _client: MediaTypeContext;
@@ -20,7 +20,7 @@ export class MediaTypeClient {
   public readonly pipeline: Pipeline;
 
   /** Test the payload with different media types and different types of the payload itself. */
-  constructor(options: MediaTypeClientOptions = {}) {
+  constructor(options: MediaTypeClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/api/index.ts
@@ -4,6 +4,6 @@
 export { list } from "./operations.js";
 export {
   createPageable,
-  PageableClientOptions,
+  PageableClientOptionalParams,
   PageableContext,
 } from "./pageableContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/api/pageableContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/api/pageableContext.ts
@@ -6,13 +6,13 @@ import { PageableContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface PageableClientOptions extends ClientOptions {}
+export interface PageableClientOptionalParams extends ClientOptions {}
 
 export { PageableContext } from "../rest/index.js";
 
 /** Test describing pageable. */
 export function createPageable(
-  options: PageableClientOptions = {},
+  options: PageableClientOptionalParams = {},
 ): PageableContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { PageableClient, PageableClientOptions } from "./pageableClient.js";
+export {
+  PageableClient,
+  PageableClientOptionalParams,
+} from "./pageableClient.js";
 export {
   User,
   ListOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/pageableClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/pageableClient.ts
@@ -8,11 +8,11 @@ import { PagedAsyncIterableIterator } from "./models/pagingTypes.js";
 import {
   list,
   createPageable,
-  PageableClientOptions,
+  PageableClientOptionalParams,
   PageableContext,
 } from "./api/index.js";
 
-export { PageableClientOptions } from "./api/pageableContext.js";
+export { PageableClientOptionalParams } from "./api/pageableContext.js";
 
 export class PageableClient {
   private _client: PageableContext;
@@ -20,7 +20,7 @@ export class PageableClient {
   public readonly pipeline: Pipeline;
 
   /** Test describing pageable. */
-  constructor(options: PageableClientOptions = {}) {
+  constructor(options: PageableClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/api/index.ts
@@ -1,5 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { createJson, JsonClientOptions, JsonContext } from "./jsonContext.js";
+export {
+  createJson,
+  JsonClientOptionalParams,
+  JsonContext,
+} from "./jsonContext.js";
 export { send, get } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/api/jsonContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/api/jsonContext.ts
@@ -6,12 +6,14 @@ import { JsonContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface JsonClientOptions extends ClientOptions {}
+export interface JsonClientOptionalParams extends ClientOptions {}
 
 export { JsonContext } from "../rest/index.js";
 
 /** Projection */
-export function createJson(options: JsonClientOptions = {}): JsonContext {
+export function createJson(
+  options: JsonClientOptionalParams = {},
+): JsonContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { JsonClient, JsonClientOptions } from "./jsonClient.js";
+export { JsonClient, JsonClientOptionalParams } from "./jsonClient.js";
 export {
   JsonEncodedNameModel,
   SendOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/jsonClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/jsonClient.ts
@@ -6,13 +6,13 @@ import { JsonEncodedNameModel } from "./models/models.js";
 import { SendOptionalParams, GetOptionalParams } from "./models/options.js";
 import {
   createJson,
-  JsonClientOptions,
+  JsonClientOptionalParams,
   JsonContext,
   send,
   get,
 } from "./api/index.js";
 
-export { JsonClientOptions } from "./api/jsonContext.js";
+export { JsonClientOptionalParams } from "./api/jsonContext.js";
 
 export class JsonClient {
   private _client: JsonContext;
@@ -20,7 +20,7 @@ export class JsonClient {
   public readonly pipeline: Pipeline;
 
   /** Projection */
-  constructor(options: JsonClientOptions = {}) {
+  constructor(options: JsonClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/server/endpoint/not-defined/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/endpoint/not-defined/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createNotDefined,
-  NotDefinedClientOptions,
+  NotDefinedClientOptionalParams,
   NotDefinedContext,
 } from "./notDefinedContext.js";
 export { valid } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/server/endpoint/not-defined/src/api/notDefinedContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/endpoint/not-defined/src/api/notDefinedContext.ts
@@ -6,14 +6,14 @@ import { NotDefinedContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface NotDefinedClientOptions extends ClientOptions {}
+export interface NotDefinedClientOptionalParams extends ClientOptions {}
 
 export { NotDefinedContext } from "../rest/index.js";
 
 /** Illustrates server doesn't define endpoint. Client should automatically add an endpoint to let user pass in. */
 export function createNotDefined(
   endpoint: string,
-  options: NotDefinedClientOptions = {},
+  options: NotDefinedClientOptionalParams = {},
 ): NotDefinedContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/server/endpoint/not-defined/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/endpoint/not-defined/src/index.ts
@@ -3,6 +3,6 @@
 
 export {
   NotDefinedClient,
-  NotDefinedClientOptions,
+  NotDefinedClientOptionalParams,
 } from "./notDefinedClient.js";
 export { ValidOptionalParams } from "./models/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/server/endpoint/not-defined/src/notDefinedClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/endpoint/not-defined/src/notDefinedClient.ts
@@ -4,13 +4,13 @@
 import { Pipeline } from "@azure/core-rest-pipeline";
 import {
   createNotDefined,
-  NotDefinedClientOptions,
+  NotDefinedClientOptionalParams,
   NotDefinedContext,
   valid,
 } from "./api/index.js";
 import { ValidOptionalParams } from "./models/options.js";
 
-export { NotDefinedClientOptions } from "./api/notDefinedContext.js";
+export { NotDefinedClientOptionalParams } from "./api/notDefinedContext.js";
 
 export class NotDefinedClient {
   private _client: NotDefinedContext;
@@ -18,7 +18,7 @@ export class NotDefinedClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates server doesn't define endpoint. Client should automatically add an endpoint to let user pass in. */
-  constructor(endpoint: string, options: NotDefinedClientOptions = {}) {
+  constructor(endpoint: string, options: NotDefinedClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/server/path/multiple/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/path/multiple/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createMultiple,
-  MultipleClientOptions,
+  MultipleClientOptionalParams,
   MultipleContext,
 } from "./multipleContext.js";
 export { noOperationParams, withOperationPathParam } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/server/path/multiple/src/api/multipleContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/path/multiple/src/api/multipleContext.ts
@@ -7,7 +7,7 @@ import { MultipleContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface MultipleClientOptions extends ClientOptions {
+export interface MultipleClientOptionalParams extends ClientOptions {
   /** Pass in v1.0 for API version. */
   apiVersion?: Versions;
 }
@@ -16,7 +16,7 @@ export { MultipleContext } from "../rest/index.js";
 
 export function createMultiple(
   endpointParam: string,
-  options: MultipleClientOptions = {},
+  options: MultipleClientOptionalParams = {},
 ): MultipleContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/server/path/multiple/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/path/multiple/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { MultipleClient, MultipleClientOptions } from "./multipleClient.js";
+export {
+  MultipleClient,
+  MultipleClientOptionalParams,
+} from "./multipleClient.js";
 export {
   Versions,
   NoOperationParamsOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/server/path/multiple/src/multipleClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/path/multiple/src/multipleClient.ts
@@ -8,20 +8,23 @@ import {
 } from "./models/options.js";
 import {
   createMultiple,
-  MultipleClientOptions,
+  MultipleClientOptionalParams,
   MultipleContext,
   noOperationParams,
   withOperationPathParam,
 } from "./api/index.js";
 
-export { MultipleClientOptions } from "./api/multipleContext.js";
+export { MultipleClientOptionalParams } from "./api/multipleContext.js";
 
 export class MultipleClient {
   private _client: MultipleContext;
   /** The pipeline used by this client to make requests */
   public readonly pipeline: Pipeline;
 
-  constructor(endpointParam: string, options: MultipleClientOptions = {}) {
+  constructor(
+    endpointParam: string,
+    options: MultipleClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/api/index.ts
@@ -4,6 +4,6 @@
 export { myOp } from "./operations.js";
 export {
   createSingle,
-  SingleClientOptions,
+  SingleClientOptionalParams,
   SingleContext,
 } from "./singleContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/api/singleContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/api/singleContext.ts
@@ -6,14 +6,14 @@ import { SingleContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface SingleClientOptions extends ClientOptions {}
+export interface SingleClientOptionalParams extends ClientOptions {}
 
 export { SingleContext } from "../rest/index.js";
 
 /** Illustrates server with a single path parameter @server */
 export function createSingle(
   endpointParam: string,
-  options: SingleClientOptions = {},
+  options: SingleClientOptionalParams = {},
 ): SingleContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { SingleClient, SingleClientOptions } from "./singleClient.js";
+export { SingleClient, SingleClientOptionalParams } from "./singleClient.js";
 export { MyOpOptionalParams } from "./models/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/singleClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/singleClient.ts
@@ -5,12 +5,12 @@ import { Pipeline } from "@azure/core-rest-pipeline";
 import {
   myOp,
   createSingle,
-  SingleClientOptions,
+  SingleClientOptionalParams,
   SingleContext,
 } from "./api/index.js";
 import { MyOpOptionalParams } from "./models/options.js";
 
-export { SingleClientOptions } from "./api/singleContext.js";
+export { SingleClientOptionalParams } from "./api/singleContext.js";
 
 export class SingleClient {
   private _client: SingleContext;
@@ -18,7 +18,7 @@ export class SingleClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates server with a single path parameter @server */
-  constructor(endpointParam: string, options: SingleClientOptions = {}) {
+  constructor(endpointParam: string, options: SingleClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/server/versions/not-versioned/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/versions/not-versioned/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createNotVersioned,
-  NotVersionedClientOptions,
+  NotVersionedClientOptionalParams,
   NotVersionedContext,
 } from "./notVersionedContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/server/versions/not-versioned/src/api/notVersionedContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/versions/not-versioned/src/api/notVersionedContext.ts
@@ -6,14 +6,14 @@ import { NotVersionedContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface NotVersionedClientOptions extends ClientOptions {}
+export interface NotVersionedClientOptionalParams extends ClientOptions {}
 
 export { NotVersionedContext } from "../rest/index.js";
 
 /** Illustrates not-versioned server. */
 export function createNotVersioned(
   endpointParam: string,
-  options: NotVersionedClientOptions = {},
+  options: NotVersionedClientOptionalParams = {},
 ): NotVersionedContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/server/versions/not-versioned/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/versions/not-versioned/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   NotVersionedClient,
-  NotVersionedClientOptions,
+  NotVersionedClientOptionalParams,
 } from "./notVersionedClient.js";
 export {
   WithoutApiVersionOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/server/versions/not-versioned/src/notVersionedClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/versions/not-versioned/src/notVersionedClient.ts
@@ -4,7 +4,7 @@
 import { Pipeline } from "@azure/core-rest-pipeline";
 import {
   createNotVersioned,
-  NotVersionedClientOptions,
+  NotVersionedClientOptionalParams,
   NotVersionedContext,
   withoutApiVersion,
   withQueryApiVersion,
@@ -16,7 +16,7 @@ import {
   WithPathApiVersionOptionalParams,
 } from "./models/options.js";
 
-export { NotVersionedClientOptions } from "./api/notVersionedContext.js";
+export { NotVersionedClientOptionalParams } from "./api/notVersionedContext.js";
 
 export class NotVersionedClient {
   private _client: NotVersionedContext;
@@ -24,7 +24,10 @@ export class NotVersionedClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates not-versioned server. */
-  constructor(endpointParam: string, options: NotVersionedClientOptions = {}) {
+  constructor(
+    endpointParam: string,
+    options: NotVersionedClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/server/versions/versioned/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/versions/versioned/src/api/index.ts
@@ -9,6 +9,6 @@ export {
 } from "./operations.js";
 export {
   createVersioned,
-  VersionedClientOptions,
+  VersionedClientOptionalParams,
   VersionedContext,
 } from "./versionedContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/server/versions/versioned/src/api/versionedContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/versions/versioned/src/api/versionedContext.ts
@@ -6,14 +6,14 @@ import { VersionedContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface VersionedClientOptions extends ClientOptions {}
+export interface VersionedClientOptionalParams extends ClientOptions {}
 
 export { VersionedContext } from "../rest/index.js";
 
 /** Illustrates versioned server. */
 export function createVersioned(
   endpointParam: string,
-  options: VersionedClientOptions = {},
+  options: VersionedClientOptionalParams = {},
 ): VersionedContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/server/versions/versioned/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/versions/versioned/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { VersionedClient, VersionedClientOptions } from "./versionedClient.js";
+export {
+  VersionedClient,
+  VersionedClientOptionalParams,
+} from "./versionedClient.js";
 export {
   Versions,
   WithoutApiVersionOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/server/versions/versioned/src/versionedClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/versions/versioned/src/versionedClient.ts
@@ -14,11 +14,11 @@ import {
   withPathApiVersion,
   withQueryOldApiVersion,
   createVersioned,
-  VersionedClientOptions,
+  VersionedClientOptionalParams,
   VersionedContext,
 } from "./api/index.js";
 
-export { VersionedClientOptions } from "./api/versionedContext.js";
+export { VersionedClientOptionalParams } from "./api/versionedContext.js";
 
 export class VersionedClient {
   private _client: VersionedContext;
@@ -26,7 +26,10 @@ export class VersionedClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates versioned server. */
-  constructor(endpointParam: string, options: VersionedClientOptions = {}) {
+  constructor(
+    endpointParam: string,
+    options: VersionedClientOptionalParams = {},
+  ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/api/index.ts
@@ -4,6 +4,6 @@
 export { immediateSuccess } from "./operations.js";
 export {
   createRepeatability,
-  RepeatabilityClientOptions,
+  RepeatabilityClientOptionalParams,
   RepeatabilityContext,
 } from "./repeatabilityContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/api/repeatabilityContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/api/repeatabilityContext.ts
@@ -6,13 +6,13 @@ import { RepeatabilityContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface RepeatabilityClientOptions extends ClientOptions {}
+export interface RepeatabilityClientOptionalParams extends ClientOptions {}
 
 export { RepeatabilityContext } from "../rest/index.js";
 
 /** Illustrates OASIS repeatability headers */
 export function createRepeatability(
-  options: RepeatabilityClientOptions = {},
+  options: RepeatabilityClientOptionalParams = {},
 ): RepeatabilityContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/index.ts
@@ -3,6 +3,6 @@
 
 export {
   RepeatabilityClient,
-  RepeatabilityClientOptions,
+  RepeatabilityClientOptionalParams,
 } from "./repeatabilityClient.js";
 export { ImmediateSuccessOptionalParams } from "./models/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/repeatabilityClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/repeatabilityClient.ts
@@ -5,12 +5,12 @@ import { Pipeline } from "@azure/core-rest-pipeline";
 import {
   immediateSuccess,
   createRepeatability,
-  RepeatabilityClientOptions,
+  RepeatabilityClientOptionalParams,
   RepeatabilityContext,
 } from "./api/index.js";
 import { ImmediateSuccessOptionalParams } from "./models/options.js";
 
-export { RepeatabilityClientOptions } from "./api/repeatabilityContext.js";
+export { RepeatabilityClientOptionalParams } from "./api/repeatabilityContext.js";
 
 export class RepeatabilityClient {
   private _client: RepeatabilityContext;
@@ -18,7 +18,7 @@ export class RepeatabilityClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates OASIS repeatability headers */
-  constructor(options: RepeatabilityClientOptions = {}) {
+  constructor(options: RepeatabilityClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createSpecialWords,
-  SpecialWordsClientOptions,
+  SpecialWordsClientOptionalParams,
   SpecialWordsContext,
 } from "./specialWordsContext.js";
 export { modelPropertiesSameAsModel } from "./modelProperties/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/specialWordsContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/specialWordsContext.ts
@@ -6,7 +6,7 @@ import { SpecialWordsContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface SpecialWordsClientOptions extends ClientOptions {}
+export interface SpecialWordsClientOptionalParams extends ClientOptions {}
 
 export { SpecialWordsContext } from "../rest/index.js";
 
@@ -51,7 +51,7 @@ export { SpecialWordsContext } from "../rest/index.js";
  * ```
  */
 export function createSpecialWords(
-  options: SpecialWordsClientOptions = {},
+  options: SpecialWordsClientOptionalParams = {},
 ): SpecialWordsContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/special-words/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-words/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   SpecialWordsClient,
-  SpecialWordsClientOptions,
+  SpecialWordsClientOptionalParams,
 } from "./specialWordsClient.js";
 export {
   SameAsModel,

--- a/packages/typespec-ts/test/modularIntegration/generated/special-words/src/specialWordsClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-words/src/specialWordsClient.ts
@@ -20,11 +20,11 @@ import {
 } from "./classic/parameters/index.js";
 import {
   createSpecialWords,
-  SpecialWordsClientOptions,
+  SpecialWordsClientOptionalParams,
   SpecialWordsContext,
 } from "./api/index.js";
 
-export { SpecialWordsClientOptions } from "./api/specialWordsContext.js";
+export { SpecialWordsClientOptionalParams } from "./api/specialWordsContext.js";
 
 export class SpecialWordsClient {
   private _client: SpecialWordsContext;
@@ -71,7 +71,7 @@ export class SpecialWordsClient {
    * yield
    * ```
    */
-  constructor(options: SpecialWordsClientOptions = {}) {
+  constructor(options: SpecialWordsClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/array/src/api/arrayContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/array/src/api/arrayContext.ts
@@ -6,12 +6,14 @@ import { ArrayContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ArrayClientOptions extends ClientOptions {}
+export interface ArrayClientOptionalParams extends ClientOptions {}
 
 export { ArrayContext } from "../rest/index.js";
 
 /** Illustrates various types of arrays. */
-export function createArray(options: ArrayClientOptions = {}): ArrayContext {
+export function createArray(
+  options: ArrayClientOptionalParams = {},
+): ArrayContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/array/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/array/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createArray,
-  ArrayClientOptions,
+  ArrayClientOptionalParams,
   ArrayContext,
 } from "./arrayContext.js";
 export { booleanValueGet, booleanValuePut } from "./booleanValue/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/array/src/arrayClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/array/src/arrayClient.ts
@@ -58,9 +58,13 @@ import {
   getNullableModelValueOperations,
   NullableModelValueOperations,
 } from "./classic/nullableModelValue/index.js";
-import { createArray, ArrayClientOptions, ArrayContext } from "./api/index.js";
+import {
+  createArray,
+  ArrayClientOptionalParams,
+  ArrayContext,
+} from "./api/index.js";
 
-export { ArrayClientOptions } from "./api/arrayContext.js";
+export { ArrayClientOptionalParams } from "./api/arrayContext.js";
 
 export class ArrayClient {
   private _client: ArrayContext;
@@ -68,7 +72,7 @@ export class ArrayClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates various types of arrays. */
-  constructor(options: ArrayClientOptions = {}) {
+  constructor(options: ArrayClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/array/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/array/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { ArrayClient, ArrayClientOptions } from "./arrayClient.js";
+export { ArrayClient, ArrayClientOptionalParams } from "./arrayClient.js";
 export {
   InnerModel,
   Int32ValueGetOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/api/dictionaryContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/api/dictionaryContext.ts
@@ -6,13 +6,13 @@ import { DictionaryContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface DictionaryClientOptions extends ClientOptions {}
+export interface DictionaryClientOptionalParams extends ClientOptions {}
 
 export { DictionaryContext } from "../rest/index.js";
 
 /** Illustrates various of dictionaries. */
 export function createDictionary(
-  options: DictionaryClientOptions = {},
+  options: DictionaryClientOptionalParams = {},
 ): DictionaryContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createDictionary,
-  DictionaryClientOptions,
+  DictionaryClientOptionalParams,
   DictionaryContext,
 } from "./dictionaryContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/dictionaryClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/dictionaryClient.ts
@@ -48,11 +48,11 @@ import {
 } from "./classic/nullableFloatValue/index.js";
 import {
   createDictionary,
-  DictionaryClientOptions,
+  DictionaryClientOptionalParams,
   DictionaryContext,
 } from "./api/index.js";
 
-export { DictionaryClientOptions } from "./api/dictionaryContext.js";
+export { DictionaryClientOptionalParams } from "./api/dictionaryContext.js";
 
 export class DictionaryClient {
   private _client: DictionaryContext;
@@ -60,7 +60,7 @@ export class DictionaryClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates various of dictionaries. */
-  constructor(options: DictionaryClientOptions = {}) {
+  constructor(options: DictionaryClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   DictionaryClient,
-  DictionaryClientOptions,
+  DictionaryClientOptionalParams,
 } from "./dictionaryClient.js";
 export {
   InnerModel,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/enum/extensible/src/api/extensibleContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/enum/extensible/src/api/extensibleContext.ts
@@ -6,12 +6,12 @@ import { ExtensibleContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ExtensibleClientOptions extends ClientOptions {}
+export interface ExtensibleClientOptionalParams extends ClientOptions {}
 
 export { ExtensibleContext } from "../rest/index.js";
 
 export function createExtensible(
-  options: ExtensibleClientOptions = {},
+  options: ExtensibleClientOptionalParams = {},
 ): ExtensibleContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/enum/extensible/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/enum/extensible/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createExtensible,
-  ExtensibleClientOptions,
+  ExtensibleClientOptionalParams,
   ExtensibleContext,
 } from "./extensibleContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/enum/extensible/src/extensibleClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/enum/extensible/src/extensibleClient.ts
@@ -8,18 +8,18 @@ import {
 } from "./classic/string/index.js";
 import {
   createExtensible,
-  ExtensibleClientOptions,
+  ExtensibleClientOptionalParams,
   ExtensibleContext,
 } from "./api/index.js";
 
-export { ExtensibleClientOptions } from "./api/extensibleContext.js";
+export { ExtensibleClientOptionalParams } from "./api/extensibleContext.js";
 
 export class ExtensibleClient {
   private _client: ExtensibleContext;
   /** The pipeline used by this client to make requests */
   public readonly pipeline: Pipeline;
 
-  constructor(options: ExtensibleClientOptions = {}) {
+  constructor(options: ExtensibleClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/enum/extensible/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/enum/extensible/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   ExtensibleClient,
-  ExtensibleClientOptions,
+  ExtensibleClientOptionalParams,
 } from "./extensibleClient.js";
 export {
   DaysOfWeekExtensibleEnum,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/enum/fixed/src/api/fixedContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/enum/fixed/src/api/fixedContext.ts
@@ -6,11 +6,13 @@ import { FixedContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface FixedClientOptions extends ClientOptions {}
+export interface FixedClientOptionalParams extends ClientOptions {}
 
 export { FixedContext } from "../rest/index.js";
 
-export function createFixed(options: FixedClientOptions = {}): FixedContext {
+export function createFixed(
+  options: FixedClientOptionalParams = {},
+): FixedContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/enum/fixed/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/enum/fixed/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createFixed,
-  FixedClientOptions,
+  FixedClientOptionalParams,
   FixedContext,
 } from "./fixedContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/enum/fixed/src/fixedClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/enum/fixed/src/fixedClient.ts
@@ -6,16 +6,20 @@ import {
   getStringOperations,
   StringOperations,
 } from "./classic/string/index.js";
-import { createFixed, FixedClientOptions, FixedContext } from "./api/index.js";
+import {
+  createFixed,
+  FixedClientOptionalParams,
+  FixedContext,
+} from "./api/index.js";
 
-export { FixedClientOptions } from "./api/fixedContext.js";
+export { FixedClientOptionalParams } from "./api/fixedContext.js";
 
 export class FixedClient {
   private _client: FixedContext;
   /** The pipeline used by this client to make requests */
   public readonly pipeline: Pipeline;
 
-  constructor(options: FixedClientOptions = {}) {
+  constructor(options: FixedClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/enum/fixed/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/enum/fixed/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { FixedClient, FixedClientOptions } from "./fixedClient.js";
+export { FixedClient, FixedClientOptionalParams } from "./fixedClient.js";
 export {
   DaysOfWeekEnum,
   StringGetKnownValueOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/empty/generated/src/api/emptyContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/empty/generated/src/api/emptyContext.ts
@@ -6,12 +6,14 @@ import { EmptyContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface EmptyClientOptions extends ClientOptions {}
+export interface EmptyClientOptionalParams extends ClientOptions {}
 
 export { EmptyContext } from "../rest/index.js";
 
 /** Illustrates usage of empty model used in operation's parameters and responses. */
-export function createEmpty(options: EmptyClientOptions = {}): EmptyContext {
+export function createEmpty(
+  options: EmptyClientOptionalParams = {},
+): EmptyContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/empty/generated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/empty/generated/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createEmpty,
-  EmptyClientOptions,
+  EmptyClientOptionalParams,
   EmptyContext,
 } from "./emptyContext.js";
 export { putEmpty, getEmpty, postRoundTripEmpty } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/empty/generated/src/emptyClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/empty/generated/src/emptyClient.ts
@@ -10,14 +10,14 @@ import {
 } from "./models/options.js";
 import {
   createEmpty,
-  EmptyClientOptions,
+  EmptyClientOptionalParams,
   EmptyContext,
   putEmpty,
   getEmpty,
   postRoundTripEmpty,
 } from "./api/index.js";
 
-export { EmptyClientOptions } from "./api/emptyContext.js";
+export { EmptyClientOptionalParams } from "./api/emptyContext.js";
 
 export class EmptyClient {
   private _client: EmptyContext;
@@ -25,7 +25,7 @@ export class EmptyClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates usage of empty model used in operation's parameters and responses. */
-  constructor(options: EmptyClientOptions = {}) {
+  constructor(options: EmptyClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/empty/generated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/empty/generated/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { EmptyClient, EmptyClientOptions } from "./emptyClient.js";
+export { EmptyClient, EmptyClientOptionalParams } from "./emptyClient.js";
 export {
   EmptyInput,
   EmptyOutput,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/flatten/generated/src/api/flattenContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/flatten/generated/src/api/flattenContext.ts
@@ -6,13 +6,13 @@ import { FlattenContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface FlattenClientOptions extends ClientOptions {}
+export interface FlattenClientOptionalParams extends ClientOptions {}
 
 export { FlattenContext } from "../rest/index.js";
 
 /** Illustrates the model flatten cases. */
 export function createFlatten(
-  options: FlattenClientOptions = {},
+  options: FlattenClientOptionalParams = {},
 ): FlattenContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/flatten/generated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/flatten/generated/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createFlatten,
-  FlattenClientOptions,
+  FlattenClientOptionalParams,
   FlattenContext,
 } from "./flattenContext.js";
 export { putFlattenModel, putNestedFlattenModel } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/flatten/generated/src/flattenClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/flatten/generated/src/flattenClient.ts
@@ -9,13 +9,13 @@ import {
 } from "./models/options.js";
 import {
   createFlatten,
-  FlattenClientOptions,
+  FlattenClientOptionalParams,
   FlattenContext,
   putFlattenModel,
   putNestedFlattenModel,
 } from "./api/index.js";
 
-export { FlattenClientOptions } from "./api/flattenContext.js";
+export { FlattenClientOptionalParams } from "./api/flattenContext.js";
 
 export class FlattenClient {
   private _client: FlattenContext;
@@ -23,7 +23,7 @@ export class FlattenClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates the model flatten cases. */
-  constructor(options: FlattenClientOptions = {}) {
+  constructor(options: FlattenClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/flatten/generated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/flatten/generated/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { FlattenClient, FlattenClientOptions } from "./flattenClient.js";
+export { FlattenClient, FlattenClientOptionalParams } from "./flattenClient.js";
 export {
   FlattenModel,
   ChildModel,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/enum-discriminator/src/api/enumDiscriminatorContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/enum-discriminator/src/api/enumDiscriminatorContext.ts
@@ -6,13 +6,13 @@ import { EnumDiscriminatorContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface EnumDiscriminatorClientOptions extends ClientOptions {}
+export interface EnumDiscriminatorClientOptionalParams extends ClientOptions {}
 
 export { EnumDiscriminatorContext } from "../rest/index.js";
 
 /** Illustrates inheritance with enum discriminator. */
 export function createEnumDiscriminator(
-  options: EnumDiscriminatorClientOptions = {},
+  options: EnumDiscriminatorClientOptionalParams = {},
 ): EnumDiscriminatorContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/enum-discriminator/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/enum-discriminator/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createEnumDiscriminator,
-  EnumDiscriminatorClientOptions,
+  EnumDiscriminatorClientOptionalParams,
   EnumDiscriminatorContext,
 } from "./enumDiscriminatorContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/enum-discriminator/src/enumDiscriminatorClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/enum-discriminator/src/enumDiscriminatorClient.ts
@@ -15,7 +15,7 @@ import {
 } from "./models/options.js";
 import {
   createEnumDiscriminator,
-  EnumDiscriminatorClientOptions,
+  EnumDiscriminatorClientOptionalParams,
   EnumDiscriminatorContext,
   getExtensibleModel,
   putExtensibleModel,
@@ -27,7 +27,7 @@ import {
   getFixedModelWrongDiscriminator,
 } from "./api/index.js";
 
-export { EnumDiscriminatorClientOptions } from "./api/enumDiscriminatorContext.js";
+export { EnumDiscriminatorClientOptionalParams } from "./api/enumDiscriminatorContext.js";
 
 export class EnumDiscriminatorClient {
   private _client: EnumDiscriminatorContext;
@@ -35,7 +35,7 @@ export class EnumDiscriminatorClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates inheritance with enum discriminator. */
-  constructor(options: EnumDiscriminatorClientOptions = {}) {
+  constructor(options: EnumDiscriminatorClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/enum-discriminator/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/enum-discriminator/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   EnumDiscriminatorClient,
-  EnumDiscriminatorClientOptions,
+  EnumDiscriminatorClientOptionalParams,
 } from "./enumDiscriminatorClient.js";
 export {
   Dog,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createNestedDiscriminator,
-  NestedDiscriminatorClientOptions,
+  NestedDiscriminatorClientOptionalParams,
   NestedDiscriminatorContext,
 } from "./nestedDiscriminatorContext.js";
 export {

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/api/nestedDiscriminatorContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/api/nestedDiscriminatorContext.ts
@@ -6,13 +6,14 @@ import { NestedDiscriminatorContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface NestedDiscriminatorClientOptions extends ClientOptions {}
+export interface NestedDiscriminatorClientOptionalParams
+  extends ClientOptions {}
 
 export { NestedDiscriminatorContext } from "../rest/index.js";
 
 /** Illustrates multiple level inheritance with multiple discriminators. */
 export function createNestedDiscriminator(
-  options: NestedDiscriminatorClientOptions = {},
+  options: NestedDiscriminatorClientOptionalParams = {},
 ): NestedDiscriminatorContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   NestedDiscriminatorClient,
-  NestedDiscriminatorClientOptions,
+  NestedDiscriminatorClientOptionalParams,
 } from "./nestedDiscriminatorClient.js";
 export {
   Fish,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/nestedDiscriminatorClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/nestedDiscriminatorClient.ts
@@ -13,7 +13,7 @@ import {
 } from "./models/options.js";
 import {
   createNestedDiscriminator,
-  NestedDiscriminatorClientOptions,
+  NestedDiscriminatorClientOptionalParams,
   NestedDiscriminatorContext,
   getModel,
   putModel,
@@ -23,7 +23,7 @@ import {
   getWrongDiscriminator,
 } from "./api/index.js";
 
-export { NestedDiscriminatorClientOptions } from "./api/nestedDiscriminatorContext.js";
+export { NestedDiscriminatorClientOptionalParams } from "./api/nestedDiscriminatorContext.js";
 
 export class NestedDiscriminatorClient {
   private _client: NestedDiscriminatorContext;
@@ -31,7 +31,7 @@ export class NestedDiscriminatorClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates multiple level inheritance with multiple discriminators. */
-  constructor(options: NestedDiscriminatorClientOptions = {}) {
+  constructor(options: NestedDiscriminatorClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createNotDiscriminated,
-  NotDiscriminatedClientOptions,
+  NotDiscriminatedClientOptionalParams,
   NotDiscriminatedContext,
 } from "./notDiscriminatedContext.js";
 export { postValid, getValid, putValid } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/api/notDiscriminatedContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/api/notDiscriminatedContext.ts
@@ -6,13 +6,13 @@ import { NotDiscriminatedContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface NotDiscriminatedClientOptions extends ClientOptions {}
+export interface NotDiscriminatedClientOptionalParams extends ClientOptions {}
 
 export { NotDiscriminatedContext } from "../rest/index.js";
 
 /** Illustrates not-discriminated inheritance model. */
 export function createNotDiscriminated(
-  options: NotDiscriminatedClientOptions = {},
+  options: NotDiscriminatedClientOptionalParams = {},
 ): NotDiscriminatedContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   NotDiscriminatedClient,
-  NotDiscriminatedClientOptions,
+  NotDiscriminatedClientOptionalParams,
 } from "./notDiscriminatedClient.js";
 export {
   Pet,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/notDiscriminatedClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/notDiscriminatedClient.ts
@@ -10,14 +10,14 @@ import {
 } from "./models/options.js";
 import {
   createNotDiscriminated,
-  NotDiscriminatedClientOptions,
+  NotDiscriminatedClientOptionalParams,
   NotDiscriminatedContext,
   postValid,
   getValid,
   putValid,
 } from "./api/index.js";
 
-export { NotDiscriminatedClientOptions } from "./api/notDiscriminatedContext.js";
+export { NotDiscriminatedClientOptionalParams } from "./api/notDiscriminatedContext.js";
 
 export class NotDiscriminatedClient {
   private _client: NotDiscriminatedContext;
@@ -25,7 +25,7 @@ export class NotDiscriminatedClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates not-discriminated inheritance model. */
-  constructor(options: NotDiscriminatedClientOptions = {}) {
+  constructor(options: NotDiscriminatedClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/api/index.ts
@@ -4,6 +4,6 @@
 export { put, get } from "./operations.js";
 export {
   createRecursive,
-  RecursiveClientOptions,
+  RecursiveClientOptionalParams,
   RecursiveContext,
 } from "./recursiveContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/api/recursiveContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/api/recursiveContext.ts
@@ -6,13 +6,13 @@ import { RecursiveContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface RecursiveClientOptions extends ClientOptions {}
+export interface RecursiveClientOptionalParams extends ClientOptions {}
 
 export { RecursiveContext } from "../rest/index.js";
 
 /** Illustrates inheritance recursion */
 export function createRecursive(
-  options: RecursiveClientOptions = {},
+  options: RecursiveClientOptionalParams = {},
 ): RecursiveContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { RecursiveClient, RecursiveClientOptions } from "./recursiveClient.js";
+export {
+  RecursiveClient,
+  RecursiveClientOptionalParams,
+} from "./recursiveClient.js";
 export {
   Element,
   Extension,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/recursiveClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/recursiveClient.ts
@@ -8,11 +8,11 @@ import {
   put,
   get,
   createRecursive,
-  RecursiveClientOptions,
+  RecursiveClientOptionalParams,
   RecursiveContext,
 } from "./api/index.js";
 
-export { RecursiveClientOptions } from "./api/recursiveContext.js";
+export { RecursiveClientOptionalParams } from "./api/recursiveContext.js";
 
 export class RecursiveClient {
   private _client: RecursiveContext;
@@ -20,7 +20,7 @@ export class RecursiveClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates inheritance recursion */
-  constructor(options: RecursiveClientOptions = {}) {
+  constructor(options: RecursiveClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/api/index.ts
@@ -12,6 +12,6 @@ export {
 } from "./operations.js";
 export {
   createSingleDiscriminator,
-  SingleDiscriminatorClientOptions,
+  SingleDiscriminatorClientOptionalParams,
   SingleDiscriminatorContext,
 } from "./singleDiscriminatorContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/api/singleDiscriminatorContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/api/singleDiscriminatorContext.ts
@@ -6,13 +6,14 @@ import { SingleDiscriminatorContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface SingleDiscriminatorClientOptions extends ClientOptions {}
+export interface SingleDiscriminatorClientOptionalParams
+  extends ClientOptions {}
 
 export { SingleDiscriminatorContext } from "../rest/index.js";
 
 /** Illustrates inheritance with single discriminator. */
 export function createSingleDiscriminator(
-  options: SingleDiscriminatorClientOptions = {},
+  options: SingleDiscriminatorClientOptionalParams = {},
 ): SingleDiscriminatorContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   SingleDiscriminatorClient,
-  SingleDiscriminatorClientOptions,
+  SingleDiscriminatorClientOptionalParams,
 } from "./singleDiscriminatorClient.js";
 export {
   Bird,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/singleDiscriminatorClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/singleDiscriminatorClient.ts
@@ -21,11 +21,11 @@ import {
   getWrongDiscriminator,
   getLegacyModel,
   createSingleDiscriminator,
-  SingleDiscriminatorClientOptions,
+  SingleDiscriminatorClientOptionalParams,
   SingleDiscriminatorContext,
 } from "./api/index.js";
 
-export { SingleDiscriminatorClientOptions } from "./api/singleDiscriminatorContext.js";
+export { SingleDiscriminatorClientOptionalParams } from "./api/singleDiscriminatorContext.js";
 
 export class SingleDiscriminatorClient {
   private _client: SingleDiscriminatorContext;
@@ -33,7 +33,7 @@ export class SingleDiscriminatorClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates inheritance with single discriminator. */
-  constructor(options: SingleDiscriminatorClientOptions = {}) {
+  constructor(options: SingleDiscriminatorClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/api/index.ts
@@ -4,6 +4,6 @@
 export { input, output, inputAndOutput } from "./operations.js";
 export {
   createUsage,
-  UsageClientOptions,
+  UsageClientOptionalParams,
   UsageContext,
 } from "./usageContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/api/usageContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/api/usageContext.ts
@@ -6,12 +6,14 @@ import { UsageContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface UsageClientOptions extends ClientOptions {}
+export interface UsageClientOptionalParams extends ClientOptions {}
 
 export { UsageContext } from "../rest/index.js";
 
 /** Illustrates usage of Record in different places(Operation parameters, return type or both). */
-export function createUsage(options: UsageClientOptions = {}): UsageContext {
+export function createUsage(
+  options: UsageClientOptionalParams = {},
+): UsageContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { UsageClient, UsageClientOptions } from "./usageClient.js";
+export { UsageClient, UsageClientOptionalParams } from "./usageClient.js";
 export {
   InputRecord,
   OutputRecord,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/usageClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/usageClient.ts
@@ -17,11 +17,11 @@ import {
   output,
   inputAndOutput,
   createUsage,
-  UsageClientOptions,
+  UsageClientOptionalParams,
   UsageContext,
 } from "./api/index.js";
 
-export { UsageClientOptions } from "./api/usageContext.js";
+export { UsageClientOptionalParams } from "./api/usageContext.js";
 
 export class UsageClient {
   private _client: UsageContext;
@@ -29,7 +29,7 @@ export class UsageClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates usage of Record in different places(Operation parameters, return type or both). */
-  constructor(options: UsageClientOptions = {}) {
+  constructor(options: UsageClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/src/additionalPropertiesClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/src/additionalPropertiesClient.ts
@@ -132,11 +132,11 @@ import {
 } from "./classic/spreadRecordNonDiscriminatedUnion3/index.js";
 import {
   createAdditionalProperties,
-  AdditionalPropertiesClientOptions,
+  AdditionalPropertiesClientOptionalParams,
   AdditionalPropertiesContext,
 } from "./api/index.js";
 
-export { AdditionalPropertiesClientOptions } from "./api/additionalPropertiesContext.js";
+export { AdditionalPropertiesClientOptionalParams } from "./api/additionalPropertiesContext.js";
 
 export class AdditionalPropertiesClient {
   private _client: AdditionalPropertiesContext;
@@ -144,7 +144,7 @@ export class AdditionalPropertiesClient {
   public readonly pipeline: Pipeline;
 
   /** Tests for additional properties of models */
-  constructor(options: AdditionalPropertiesClientOptions = {}) {
+  constructor(options: AdditionalPropertiesClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/src/api/additionalPropertiesContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/src/api/additionalPropertiesContext.ts
@@ -6,13 +6,14 @@ import { AdditionalPropertiesContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface AdditionalPropertiesClientOptions extends ClientOptions {}
+export interface AdditionalPropertiesClientOptionalParams
+  extends ClientOptions {}
 
 export { AdditionalPropertiesContext } from "../rest/index.js";
 
 /** Tests for additional properties of models */
 export function createAdditionalProperties(
-  options: AdditionalPropertiesClientOptions = {},
+  options: AdditionalPropertiesClientOptionalParams = {},
 ): AdditionalPropertiesContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createAdditionalProperties,
-  AdditionalPropertiesClientOptions,
+  AdditionalPropertiesClientOptionalParams,
   AdditionalPropertiesContext,
 } from "./additionalPropertiesContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   AdditionalPropertiesClient,
-  AdditionalPropertiesClientOptions,
+  AdditionalPropertiesClientOptionalParams,
 } from "./additionalPropertiesClient.js";
 export {
   WidgetData2,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createNullable,
-  NullableClientOptions,
+  NullableClientOptionalParams,
   NullableContext,
 } from "./nullableContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/nullableContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/nullableContext.ts
@@ -6,13 +6,13 @@ import { NullableContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface NullableClientOptions extends ClientOptions {}
+export interface NullableClientOptionalParams extends ClientOptions {}
 
 export { NullableContext } from "../rest/index.js";
 
 /** Illustrates models with nullable properties. */
 export function createNullable(
-  options: NullableClientOptions = {},
+  options: NullableClientOptionalParams = {},
 ): NullableContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { NullableClient, NullableClientOptions } from "./nullableClient.js";
+export {
+  NullableClient,
+  NullableClientOptionalParams,
+} from "./nullableClient.js";
 export {
   CollectionsStringProperty,
   CollectionsModelProperty,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/nullableClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/nullableClient.ts
@@ -29,11 +29,11 @@ import {
 } from "./classic/collectionsString/index.js";
 import {
   createNullable,
-  NullableClientOptions,
+  NullableClientOptionalParams,
   NullableContext,
 } from "./api/index.js";
 
-export { NullableClientOptions } from "./api/nullableContext.js";
+export { NullableClientOptionalParams } from "./api/nullableContext.js";
 
 export class NullableClient {
   private _client: NullableContext;
@@ -41,7 +41,7 @@ export class NullableClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates models with nullable properties. */
-  constructor(options: NullableClientOptions = {}) {
+  constructor(options: NullableClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/index.ts
@@ -3,6 +3,6 @@
 
 export {
   createOptional,
-  OptionalClientOptions,
+  OptionalClientOptionalParams,
   OptionalContext,
 } from "./optionalContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/optionalContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/optionalContext.ts
@@ -6,13 +6,13 @@ import { OptionalContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface OptionalClientOptions extends ClientOptions {}
+export interface OptionalClientOptionalParams extends ClientOptions {}
 
 export { OptionalContext } from "../rest/index.js";
 
 /** Illustrates models with optional properties. */
 export function createOptional(
-  options: OptionalClientOptions = {},
+  options: OptionalClientOptionalParams = {},
 ): OptionalContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/index.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { OptionalClient, OptionalClientOptions } from "./optionalClient.js";
+export {
+  OptionalClient,
+  OptionalClientOptionalParams,
+} from "./optionalClient.js";
 export {
   RequiredAndOptionalProperty,
   UnionFloatLiteralProperty,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/optionalClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/optionalClient.ts
@@ -57,11 +57,11 @@ import {
 } from "./classic/requiredAndOptional/index.js";
 import {
   createOptional,
-  OptionalClientOptions,
+  OptionalClientOptionalParams,
   OptionalContext,
 } from "./api/index.js";
 
-export { OptionalClientOptions } from "./api/optionalContext.js";
+export { OptionalClientOptionalParams } from "./api/optionalContext.js";
 
 export class OptionalClient {
   private _client: OptionalContext;
@@ -69,7 +69,7 @@ export class OptionalClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates models with optional properties. */
-  constructor(options: OptionalClientOptions = {}) {
+  constructor(options: OptionalClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createValueTypes,
-  ValueTypesClientOptions,
+  ValueTypesClientOptionalParams,
   ValueTypesContext,
 } from "./valueTypesContext.js";
 export { booleanGet, booleanPut } from "./boolean/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/valueTypesContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/valueTypesContext.ts
@@ -6,13 +6,13 @@ import { ValueTypesContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ValueTypesClientOptions extends ClientOptions {}
+export interface ValueTypesClientOptionalParams extends ClientOptions {}
 
 export { ValueTypesContext } from "../rest/index.js";
 
 /** Illustrates various property types for models */
 export function createValueTypes(
-  options: ValueTypesClientOptions = {},
+  options: ValueTypesClientOptionalParams = {},
 ): ValueTypesContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   ValueTypesClient,
-  ValueTypesClientOptions,
+  ValueTypesClientOptionalParams,
 } from "./valueTypesClient.js";
 export {
   UnionEnumValueProperty,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/valueTypesClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/valueTypesClient.ts
@@ -102,11 +102,11 @@ import {
 } from "./classic/unionEnumValue/index.js";
 import {
   createValueTypes,
-  ValueTypesClientOptions,
+  ValueTypesClientOptionalParams,
   ValueTypesContext,
 } from "./api/index.js";
 
-export { ValueTypesClientOptions } from "./api/valueTypesContext.js";
+export { ValueTypesClientOptionalParams } from "./api/valueTypesContext.js";
 
 export class ValueTypesClient {
   private _client: ValueTypesContext;
@@ -114,7 +114,7 @@ export class ValueTypesClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates various property types for models */
-  constructor(options: ValueTypesClientOptions = {}) {
+  constructor(options: ValueTypesClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createScalar,
-  ScalarClientOptions,
+  ScalarClientOptionalParams,
   ScalarContext,
 } from "./scalarContext.js";
 export { booleanGet, booleanPut } from "./boolean/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/scalarContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/scalarContext.ts
@@ -6,11 +6,13 @@ import { ScalarContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ScalarClientOptions extends ClientOptions {}
+export interface ScalarClientOptionalParams extends ClientOptions {}
 
 export { ScalarContext } from "../rest/index.js";
 
-export function createScalar(options: ScalarClientOptions = {}): ScalarContext {
+export function createScalar(
+  options: ScalarClientOptionalParams = {},
+): ScalarContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { ScalarClient, ScalarClientOptions } from "./scalarClient.js";
+export { ScalarClient, ScalarClientOptionalParams } from "./scalarClient.js";
 export {
   StringGetOptionalParams,
   StringPutOptionalParams,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/scalarClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/scalarClient.ts
@@ -32,18 +32,18 @@ import {
 } from "./classic/decimal128Verify/index.js";
 import {
   createScalar,
-  ScalarClientOptions,
+  ScalarClientOptionalParams,
   ScalarContext,
 } from "./api/index.js";
 
-export { ScalarClientOptions } from "./api/scalarContext.js";
+export { ScalarClientOptionalParams } from "./api/scalarContext.js";
 
 export class ScalarClient {
   private _client: ScalarContext;
   /** The pipeline used by this client to make requests */
   public readonly pipeline: Pipeline;
 
-  constructor(options: ScalarClientOptions = {}) {
+  constructor(options: ScalarClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createUnion,
-  UnionClientOptions,
+  UnionClientOptionalParams,
   UnionContext,
 } from "./unionContext.js";
 export { enumsOnlyGet, enumsOnlySend } from "./enumsOnly/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/unionContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/unionContext.ts
@@ -6,12 +6,14 @@ import { UnionContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface UnionClientOptions extends ClientOptions {}
+export interface UnionClientOptionalParams extends ClientOptions {}
 
 export { UnionContext } from "../rest/index.js";
 
 /** Describe scenarios for various combinations of unions. */
-export function createUnion(options: UnionClientOptions = {}): UnionContext {
+export function createUnion(
+  options: UnionClientOptionalParams = {},
+): UnionContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { UnionClient, UnionClientOptions } from "./unionClient.js";
+export { UnionClient, UnionClientOptionalParams } from "./unionClient.js";
 export {
   MixedTypesCases,
   Cat,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/unionClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/unionClient.ts
@@ -42,9 +42,13 @@ import {
   getMixedTypesOperations,
   MixedTypesOperations,
 } from "./classic/mixedTypes/index.js";
-import { createUnion, UnionClientOptions, UnionContext } from "./api/index.js";
+import {
+  createUnion,
+  UnionClientOptionalParams,
+  UnionContext,
+} from "./api/index.js";
 
-export { UnionClientOptions } from "./api/unionContext.js";
+export { UnionClientOptionalParams } from "./api/unionContext.js";
 
 export class UnionClient {
   private _client: UnionContext;
@@ -52,7 +56,7 @@ export class UnionClient {
   public readonly pipeline: Pipeline;
 
   /** Describe scenarios for various combinations of unions. */
-  constructor(options: UnionClientOptions = {}) {
+  constructor(options: UnionClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/added/src/addedClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/added/src/addedClient.ts
@@ -10,14 +10,14 @@ import {
 } from "./models/options.js";
 import {
   createAdded,
-  AddedClientOptions,
+  AddedClientOptionalParams,
   AddedContext,
   v1,
   v2,
   v2InInterface,
 } from "./api/index.js";
 
-export { AddedClientOptions } from "./api/addedContext.js";
+export { AddedClientOptionalParams } from "./api/addedContext.js";
 
 export class AddedClient {
   private _client: AddedContext;
@@ -28,7 +28,7 @@ export class AddedClient {
   constructor(
     endpointParam: string,
     version: Versions,
-    options: AddedClientOptions = {},
+    options: AddedClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/added/src/api/addedContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/added/src/api/addedContext.ts
@@ -7,7 +7,7 @@ import { AddedContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface AddedClientOptions extends ClientOptions {}
+export interface AddedClientOptionalParams extends ClientOptions {}
 
 export { AddedContext } from "../rest/index.js";
 
@@ -15,7 +15,7 @@ export { AddedContext } from "../rest/index.js";
 export function createAdded(
   endpointParam: string,
   version: Versions,
-  options: AddedClientOptions = {},
+  options: AddedClientOptionalParams = {},
 ): AddedContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/added/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/added/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createAdded,
-  AddedClientOptions,
+  AddedClientOptionalParams,
   AddedContext,
 } from "./addedContext.js";
 export { v1, v2, v2InInterface } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/added/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/added/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { AddedClient, AddedClientOptions } from "./addedClient.js";
+export { AddedClient, AddedClientOptionalParams } from "./addedClient.js";
 export {
   ModelV1,
   EnumV1,

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/madeOptional/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/madeOptional/src/api/index.ts
@@ -3,7 +3,7 @@
 
 export {
   createMadeOptional,
-  MadeOptionalClientOptions,
+  MadeOptionalClientOptionalParams,
   MadeOptionalContext,
 } from "./madeOptionalContext.js";
 export { test } from "./operations.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/madeOptional/src/api/madeOptionalContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/madeOptional/src/api/madeOptionalContext.ts
@@ -7,7 +7,7 @@ import { MadeOptionalContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface MadeOptionalClientOptions extends ClientOptions {}
+export interface MadeOptionalClientOptionalParams extends ClientOptions {}
 
 export { MadeOptionalContext } from "../rest/index.js";
 
@@ -15,7 +15,7 @@ export { MadeOptionalContext } from "../rest/index.js";
 export function createMadeOptional(
   endpointParam: string,
   version: Versions,
-  options: MadeOptionalClientOptions = {},
+  options: MadeOptionalClientOptionalParams = {},
 ): MadeOptionalContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/madeOptional/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/madeOptional/src/index.ts
@@ -3,6 +3,6 @@
 
 export {
   MadeOptionalClient,
-  MadeOptionalClientOptions,
+  MadeOptionalClientOptionalParams,
 } from "./madeOptionalClient.js";
 export { TestModel, Versions, TestOptionalParams } from "./models/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/madeOptional/src/madeOptionalClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/madeOptional/src/madeOptionalClient.ts
@@ -6,12 +6,12 @@ import { TestModel, Versions } from "./models/models.js";
 import { TestOptionalParams } from "./models/options.js";
 import {
   createMadeOptional,
-  MadeOptionalClientOptions,
+  MadeOptionalClientOptionalParams,
   MadeOptionalContext,
   test,
 } from "./api/index.js";
 
-export { MadeOptionalClientOptions } from "./api/madeOptionalContext.js";
+export { MadeOptionalClientOptionalParams } from "./api/madeOptionalContext.js";
 
 export class MadeOptionalClient {
   private _client: MadeOptionalContext;
@@ -22,7 +22,7 @@ export class MadeOptionalClient {
   constructor(
     endpointParam: string,
     version: Versions,
-    options: MadeOptionalClientOptions = {},
+    options: MadeOptionalClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/removed/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/removed/src/api/index.ts
@@ -4,6 +4,6 @@
 export { v2 } from "./operations.js";
 export {
   createRemoved,
-  RemovedClientOptions,
+  RemovedClientOptionalParams,
   RemovedContext,
 } from "./removedContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/removed/src/api/removedContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/removed/src/api/removedContext.ts
@@ -7,7 +7,7 @@ import { RemovedContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface RemovedClientOptions extends ClientOptions {}
+export interface RemovedClientOptionalParams extends ClientOptions {}
 
 export { RemovedContext } from "../rest/index.js";
 
@@ -15,7 +15,7 @@ export { RemovedContext } from "../rest/index.js";
 export function createRemoved(
   endpointParam: string,
   version: Versions,
-  options: RemovedClientOptions = {},
+  options: RemovedClientOptionalParams = {},
 ): RemovedContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/removed/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/removed/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export { RemovedClient, RemovedClientOptions } from "./removedClient.js";
+export { RemovedClient, RemovedClientOptionalParams } from "./removedClient.js";
 export {
   ModelV2,
   EnumV2,

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/removed/src/removedClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/removed/src/removedClient.ts
@@ -7,11 +7,11 @@ import { V2OptionalParams } from "./models/options.js";
 import {
   v2,
   createRemoved,
-  RemovedClientOptions,
+  RemovedClientOptionalParams,
   RemovedContext,
 } from "./api/index.js";
 
-export { RemovedClientOptions } from "./api/removedContext.js";
+export { RemovedClientOptionalParams } from "./api/removedContext.js";
 
 export class RemovedClient {
   private _client: RemovedContext;
@@ -22,7 +22,7 @@ export class RemovedClient {
   constructor(
     endpointParam: string,
     version: Versions,
-    options: RemovedClientOptions = {},
+    options: RemovedClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/api/index.ts
@@ -4,6 +4,6 @@
 export { newOp, newOpInNewInterface } from "./operations.js";
 export {
   createRenamedFrom,
-  RenamedFromClientOptions,
+  RenamedFromClientOptionalParams,
   RenamedFromContext,
 } from "./renamedFromContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/api/renamedFromContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/api/renamedFromContext.ts
@@ -7,7 +7,7 @@ import { RenamedFromContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface RenamedFromClientOptions extends ClientOptions {}
+export interface RenamedFromClientOptionalParams extends ClientOptions {}
 
 export { RenamedFromContext } from "../rest/index.js";
 
@@ -15,7 +15,7 @@ export { RenamedFromContext } from "../rest/index.js";
 export function createRenamedFrom(
   endpointParam: string,
   version: Versions,
-  options: RenamedFromClientOptions = {},
+  options: RenamedFromClientOptionalParams = {},
 ): RenamedFromContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/index.ts
@@ -3,7 +3,7 @@
 
 export {
   RenamedFromClient,
-  RenamedFromClientOptions,
+  RenamedFromClientOptionalParams,
 } from "./renamedFromClient.js";
 export {
   NewModel,

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/renamedFromClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/renamedFromClient.ts
@@ -11,11 +11,11 @@ import {
   newOp,
   newOpInNewInterface,
   createRenamedFrom,
-  RenamedFromClientOptions,
+  RenamedFromClientOptionalParams,
   RenamedFromContext,
 } from "./api/index.js";
 
-export { RenamedFromClientOptions } from "./api/renamedFromContext.js";
+export { RenamedFromClientOptionalParams } from "./api/renamedFromContext.js";
 
 export class RenamedFromClient {
   private _client: RenamedFromContext;
@@ -26,7 +26,7 @@ export class RenamedFromClient {
   constructor(
     endpointParam: string,
     version: Versions,
-    options: RenamedFromClientOptions = {},
+    options: RenamedFromClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/returnTypeChangedFrom/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/returnTypeChangedFrom/src/api/index.ts
@@ -4,6 +4,6 @@
 export { test } from "./operations.js";
 export {
   createReturnTypeChangedFrom,
-  ReturnTypeChangedFromClientOptions,
+  ReturnTypeChangedFromClientOptionalParams,
   ReturnTypeChangedFromContext,
 } from "./returnTypeChangedFromContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/returnTypeChangedFrom/src/api/returnTypeChangedFromContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/returnTypeChangedFrom/src/api/returnTypeChangedFromContext.ts
@@ -7,7 +7,8 @@ import { ReturnTypeChangedFromContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface ReturnTypeChangedFromClientOptions extends ClientOptions {}
+export interface ReturnTypeChangedFromClientOptionalParams
+  extends ClientOptions {}
 
 export { ReturnTypeChangedFromContext } from "../rest/index.js";
 
@@ -15,7 +16,7 @@ export { ReturnTypeChangedFromContext } from "../rest/index.js";
 export function createReturnTypeChangedFrom(
   endpointParam: string,
   version: Versions,
-  options: ReturnTypeChangedFromClientOptions = {},
+  options: ReturnTypeChangedFromClientOptionalParams = {},
 ): ReturnTypeChangedFromContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/returnTypeChangedFrom/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/returnTypeChangedFrom/src/index.ts
@@ -3,6 +3,6 @@
 
 export {
   ReturnTypeChangedFromClient,
-  ReturnTypeChangedFromClientOptions,
+  ReturnTypeChangedFromClientOptionalParams,
 } from "./returnTypeChangedFromClient.js";
 export { Versions, TestOptionalParams } from "./models/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/returnTypeChangedFrom/src/returnTypeChangedFromClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/returnTypeChangedFrom/src/returnTypeChangedFromClient.ts
@@ -7,11 +7,11 @@ import { TestOptionalParams } from "./models/options.js";
 import {
   test,
   createReturnTypeChangedFrom,
-  ReturnTypeChangedFromClientOptions,
+  ReturnTypeChangedFromClientOptionalParams,
   ReturnTypeChangedFromContext,
 } from "./api/index.js";
 
-export { ReturnTypeChangedFromClientOptions } from "./api/returnTypeChangedFromContext.js";
+export { ReturnTypeChangedFromClientOptionalParams } from "./api/returnTypeChangedFromContext.js";
 
 export class ReturnTypeChangedFromClient {
   private _client: ReturnTypeChangedFromContext;
@@ -22,7 +22,7 @@ export class ReturnTypeChangedFromClient {
   constructor(
     endpointParam: string,
     version: Versions,
-    options: ReturnTypeChangedFromClientOptions = {},
+    options: ReturnTypeChangedFromClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/api/index.ts
@@ -4,6 +4,6 @@
 export { test } from "./operations.js";
 export {
   createTypeChangedFrom,
-  TypeChangedFromClientOptions,
+  TypeChangedFromClientOptionalParams,
   TypeChangedFromContext,
 } from "./typeChangedFromContext.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/api/typeChangedFromContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/api/typeChangedFromContext.ts
@@ -7,7 +7,7 @@ import { TypeChangedFromContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface TypeChangedFromClientOptions extends ClientOptions {}
+export interface TypeChangedFromClientOptionalParams extends ClientOptions {}
 
 export { TypeChangedFromContext } from "../rest/index.js";
 
@@ -15,7 +15,7 @@ export { TypeChangedFromContext } from "../rest/index.js";
 export function createTypeChangedFrom(
   endpointParam: string,
   version: Versions,
-  options: TypeChangedFromClientOptions = {},
+  options: TypeChangedFromClientOptionalParams = {},
 ): TypeChangedFromContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/index.ts
@@ -3,6 +3,6 @@
 
 export {
   TypeChangedFromClient,
-  TypeChangedFromClientOptions,
+  TypeChangedFromClientOptionalParams,
 } from "./typeChangedFromClient.js";
 export { TestModel, Versions, TestOptionalParams } from "./models/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/typeChangedFromClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/typeChangedFromClient.ts
@@ -7,11 +7,11 @@ import { TestOptionalParams } from "./models/options.js";
 import {
   test,
   createTypeChangedFrom,
-  TypeChangedFromClientOptions,
+  TypeChangedFromClientOptionalParams,
   TypeChangedFromContext,
 } from "./api/index.js";
 
-export { TypeChangedFromClientOptions } from "./api/typeChangedFromContext.js";
+export { TypeChangedFromClientOptionalParams } from "./api/typeChangedFromContext.js";
 
 export class TypeChangedFromClient {
   private _client: TypeChangedFromContext;
@@ -22,7 +22,7 @@ export class TypeChangedFromClient {
   constructor(
     endpointParam: string,
     version: Versions,
-    options: TypeChangedFromClientOptions = {},
+    options: TypeChangedFromClientOptionalParams = {},
   ) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularUnit/apiOperations.spec.ts
+++ b/packages/typespec-ts/test/modularUnit/apiOperations.spec.ts
@@ -515,14 +515,14 @@ describe("api operations in Modular", () => {
         import getClient from "../rest/index.js";
         
         /** Optional parameters for the client. */
-        export interface TestingClientOptions  extends ClientOptions  {}
+        export interface TestingClientOptionalParams  extends ClientOptions  {}
         
         export { TestingContext } from "../rest/index.js";
         
         export function createTesting(
           endpoint: string,
           apiVersion: string,
-          options: TestingClientOptions  = {},
+          options: TestingClientOptionalParams  = {},
         ): TestingContext {
           const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
           const userAgentPrefix = prefixFromOptions
@@ -544,7 +544,7 @@ describe("api operations in Modular", () => {
         `
         import { Pipeline } from "@azure/core-rest-pipeline";
         
-        export { TestingClientOptions  } from "./api/testingContext.js";
+        export { TestingClientOptionalParams  } from "./api/testingContext.js";
         
         export class TestingClient {
           private _client: TestingContext;
@@ -554,7 +554,7 @@ describe("api operations in Modular", () => {
           constructor(
             endpoint: string,
             apiVersion: string,
-            options: TestingClientOptions  = {},
+            options: TestingClientOptionalParams  = {},
           ) {
             const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
             const userAgentPrefix = prefixFromOptions
@@ -646,7 +646,7 @@ describe("api operations in Modular", () => {
         import getClient from "../rest/index.js";
         
         /** Optional parameters for the client. */
-        export interface TestingClientOptions extends ClientOptions  {
+        export interface TestingClientOptionalParams extends ClientOptions  {
           apiVersion?: string;
         }
         
@@ -654,7 +654,7 @@ describe("api operations in Modular", () => {
         
         export function createTesting(
           endpoint: string,
-          options: TestingClientOptions  = {},
+          options: TestingClientOptionalParams  = {},
         ): TestingContext {
           const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
           const userAgentPrefix = prefixFromOptions
@@ -680,7 +680,7 @@ describe("api operations in Modular", () => {
         `
         import { Pipeline } from "@azure/core-rest-pipeline";
         
-        export { TestingClientOptions  } from "./api/testingContext.js";
+        export { TestingClientOptionalParams  } from "./api/testingContext.js";
         
         export class TestingClient {
           private _client: TestingContext;
@@ -689,7 +689,7 @@ describe("api operations in Modular", () => {
         
           constructor(
             endpoint: string,
-            options: TestingClientOptions  = {},
+            options: TestingClientOptionalParams  = {},
           ) {
             const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
             const userAgentPrefix = prefixFromOptions
@@ -811,13 +811,13 @@ describe("api operations in Modular", () => {
         import getClient from "../rest/index.js";
         
         /** Optional parameters for the client. */
-        export interface TestingClientOptions  extends ClientOptions  {}
+        export interface TestingClientOptionalParams  extends ClientOptions  {}
         
         export { TestingContext } from "../rest/index.js";
         
         export function createTesting(
           endpoint: string,
-          options: TestingClientOptions  = {},
+          options: TestingClientOptionalParams  = {},
           ): TestingContext {
           const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
           const userAgentPrefix = prefixFromOptions
@@ -839,7 +839,7 @@ describe("api operations in Modular", () => {
         `
         import { Pipeline } from "@azure/core-rest-pipeline";
         
-        export { TestingClientOptions  } from "./api/testingContext.js";
+        export { TestingClientOptionalParams  } from "./api/testingContext.js";
         
         export class TestingClient {
           private _client: TestingContext;
@@ -848,7 +848,7 @@ describe("api operations in Modular", () => {
         
           constructor(
             endpoint: string,
-            options: TestingClientOptions  = {},
+            options: TestingClientOptionalParams  = {},
           ) {
             const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
             const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/modularUnit/clientContext.spec.ts
+++ b/packages/typespec-ts/test/modularUnit/clientContext.spec.ts
@@ -63,14 +63,14 @@ describe("modular client context type", () => {
         import getClient from "../rest/index.js";
         
         /** Optional parameters for the client. */
-        export interface ServiceClientOptions  extends ClientOptions  {}
+        export interface ServiceClientOptionalParams  extends ClientOptions  {}
         
         export { ServiceContext } from "../rest/index.js";
         
         export function createService(
           endpointParam: string,
           clientParam: ClientType,
-          options: ServiceClientOptions  = {}
+          options: ServiceClientOptionalParams  = {}
         ): ServiceContext {
           const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
           const userAgentPrefix = prefixFromOptions
@@ -145,14 +145,14 @@ describe("modular client context type", () => {
         import getClient from "../rest/index.js";
         
         /** Optional parameters for the client. */
-        export interface ServiceClientOptions  extends ClientOptions  {}
+        export interface ServiceClientOptionalParams  extends ClientOptions  {}
         
         export { ServiceContext } from "../rest/index.js";
         
         export function createService(
           endpointParam: string,
           clientParam: ClientType,
-          options: ServiceClientOptions  = {}
+          options: ServiceClientOptionalParams  = {}
         ): ServiceContext {
           const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
           const userAgentPrefix = prefixFromOptions

--- a/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/api/index.ts
+++ b/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/api/index.ts
@@ -3,6 +3,6 @@
 export { input, output, inputAndOutput } from "./operations.js";
 export {
   createUsage,
-  UsageClientOptions,
+  UsageClientOptionalParams,
   UsageContext,
 } from "./usageContext.js";

--- a/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/api/usageContext.ts
+++ b/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/api/usageContext.ts
@@ -5,12 +5,14 @@ import { UsageContext } from "../rest/index.js";
 import getClient from "../rest/index.js";
 
 /** Optional parameters for the client. */
-export interface UsageClientOptions extends ClientOptions {}
+export interface UsageClientOptionalParams extends ClientOptions {}
 
 export { UsageContext } from "../rest/index.js";
 
 /** Illustrates usage of Record in different places(Operation parameters, return type or both). */
-export function createUsage(options: UsageClientOptions = {}): UsageContext {
+export function createUsage(
+  options: UsageClientOptionalParams = {},
+): UsageContext {
   const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
   const userAgentPrefix = prefixFromOptions
     ? `${prefixFromOptions} azsdk-js-api`

--- a/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/index.ts
+++ b/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/index.ts
@@ -1,6 +1,6 @@
 // Licensed under the MIT license.
 
-export { UsageClient, UsageClientOptions } from "./usageClient.js";
+export { UsageClient, UsageClientOptionalParams } from "./usageClient.js";
 export {
   InputRecord,
   OutputRecord,

--- a/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/usageClient.ts
+++ b/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/usageClient.ts
@@ -16,11 +16,11 @@ import {
   output,
   inputAndOutput,
   createUsage,
-  UsageClientOptions,
+  UsageClientOptionalParams,
   UsageContext,
 } from "./api/index.js";
 
-export { UsageClientOptions } from "./api/usageContext.js";
+export { UsageClientOptionalParams } from "./api/usageContext.js";
 
 export class UsageClient {
   private _client: UsageContext;
@@ -28,7 +28,7 @@ export class UsageClient {
   public readonly pipeline: Pipeline;
 
   /** Illustrates usage of Record in different places(Operation parameters, return type or both). */
-  constructor(options: UsageClientOptions = {}) {
+  constructor(options: UsageClientOptionalParams = {}) {
     const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;
     const userAgentPrefix = prefixFromOptions
       ? `${prefixFromOptions} azsdk-js-client`


### PR DESCRIPTION
fixes https://github.com/Azure/autorest.typescript/issues/2633

We have naming inconsistancy which caused un-necessary breakings between modular and HLC and we agreed to mitigate this breaking in above issue. So I fix in this pr.
- Modular
![image](https://github.com/Azure/autorest.typescript/assets/9943211/eea76c62-9d1e-4b3e-b2e3-449eeb4e002f)
- HLC
![image](https://github.com/Azure/autorest.typescript/assets/9943211/dc1115a1-9bf3-4c57-8e28-62bf7c199e19)