### PR TITLE
Fix the nightly build failure in smoke test because of resource issue

### DIFF
--- a/.scripts/nightly.yml
+++ b/.scripts/nightly.yml
@@ -7,6 +7,10 @@ schedules:
         - main
 pr: none
 
+pool:
+  name: azsdk-pool-mms-ubuntu-2004-general
+  vmImage: ubuntu-20.04
+
 stages:
   - stage: NightlyCI
     jobs:


### PR DESCRIPTION
Fix the nightly build failure in smoke test because of resource issue

the build is successful here: https://dev.azure.com/azure-sdk/public/_build/results?buildId=3976274&view=results