### PR TITLE
Bump ts-morph to 23.0.0

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
       sinon: ^10.0.0
       source-map-loader: ^1.0.0
       source-map-support: ^0.5.16
-      ts-morph: ^15.1.0
+      ts-morph: ^23.0.0
       ts-node: ^8.5.2
       tslib: ^2.3.1
       typescript: ~5.5.3
@@ -97,7 +97,7 @@ importers:
       lodash: 4.17.21
       prettier: 3.1.1
       source-map-support: 0.5.21
-      ts-morph: 15.1.0
+      ts-morph: 23.0.0
     devDependencies:
       '@azure-tools/test-recorder': 3.0.0
       '@azure/abort-controller': 2.1.2
@@ -163,13 +163,13 @@ importers:
       mocha: ^10.2.0
       prettier: ^3.1.0
       rimraf: ^5.0.0
-      ts-morph: ^15.1.0
+      ts-morph: ^23.0.0
       ts-node: ^10.7.0
       typescript: ~5.5.3
     dependencies:
       handlebars: 4.7.8
       lodash: 4.17.21
-      ts-morph: 15.1.0
+      ts-morph: 23.0.0
     devDependencies:
       '@types/chai': 4.3.6
       '@types/fs-extra': 8.1.3
@@ -271,7 +271,7 @@ importers:
       npm-run-all: ~4.1.5
       prettier: ^3.1.0
       rimraf: ^5.0.0
-      ts-morph: ^15.1.0
+      ts-morph: ^23.0.0
       ts-node: ~10.9.1
       tslib: ^2.3.1
       typescript: ~5.5.3
@@ -281,7 +281,7 @@ importers:
       fs-extra: 11.1.1
       lodash: 4.17.21
       prettier: 3.1.1
-      ts-morph: 15.1.0
+      ts-morph: 23.0.0
       tslib: 2.6.2
     devDependencies:
       '@azure-rest/core-client': 2.1.0
@@ -1762,12 +1762,12 @@ packages:
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
     dev: true
 
-  /@ts-morph/common/0.16.0:
-    resolution: {integrity: sha512-SgJpzkTgZKLKqQniCjLaE3c2L2sdL7UShvmTmPBejAKd2OKV/yfMpQ2IWpAuA+VY5wy7PkSUaEObIqEK6afFuw==}
+  /@ts-morph/common/0.24.0:
+    resolution: {integrity: sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==}
     dependencies:
       fast-glob: 3.3.2
-      minimatch: 5.1.6
-      mkdirp: 1.0.4
+      minimatch: 9.0.5
+      mkdirp: 3.0.1
       path-browserify: 1.0.1
     dev: false
 
@@ -2970,8 +2970,8 @@ packages:
       shallow-clone: 3.0.1
     dev: true
 
-  /code-block-writer/11.0.3:
-    resolution: {integrity: sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==}
+  /code-block-writer/13.0.2:
+    resolution: {integrity: sha512-XfXzAGiStXSmCIwrkdfvc7FS5Dtj8yelCtyOf2p2skCAfvLd6zu0rGzuS9NSCO3bq1JKpFZ7tbKdKlcd5occQA==}
     dev: false
 
   /code-error-fragment/0.0.230:
@@ -5465,6 +5465,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
+    dev: true
 
   /minimatch/9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
@@ -5472,6 +5473,13 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
     dev: true
+
+  /minimatch/9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
 
   /minimist/1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -5492,17 +5500,10 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /mkdirp/1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: false
-
   /mkdirp/3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: true
 
   /mlly/1.7.1:
     resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
@@ -7158,11 +7159,11 @@ packages:
       typescript: 5.5.3
     dev: true
 
-  /ts-morph/15.1.0:
-    resolution: {integrity: sha512-RBsGE2sDzUXFTnv8Ba22QfeuKbgvAGJFuTN7HfmIRUkgT/NaVLfDM/8OFm2NlFkGlWEXdpW5OaFIp1jvqdDuOg==}
+  /ts-morph/23.0.0:
+    resolution: {integrity: sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==}
     dependencies:
-      '@ts-morph/common': 0.16.0
-      code-block-writer: 11.0.3
+      '@ts-morph/common': 0.24.0
+      code-block-writer: 13.0.2
     dev: false
 
   /ts-node/10.9.1_zn7yththkfcgqhkmzzvsumdxyy:

--- a/packages/autorest.typescript/package.json
+++ b/packages/autorest.typescript/package.json
@@ -74,7 +74,7 @@
     "lodash": "^4.17.21",
     "prettier": "^3.1.0",
     "source-map-support": "^0.5.16",
-    "ts-morph": "^15.1.0",
+    "ts-morph": "^23.0.0",
     "@azure/core-auth": "^1.6.0",
     "@azure-tools/rlc-common": "workspace:^0.31.0"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/src/bodyComplexRestClient.ts
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/src/bodyComplexRestClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/src/paging.ts
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/src/paging.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/rlc-common/package.json
+++ b/packages/rlc-common/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ts-morph": "^15.1.0",
+    "ts-morph": "^23.0.0",
     "lodash": "^4.17.21",
     "handlebars": "^4.7.7"
   },

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/dataProducts/index.ts
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/dataProducts/index.ts
@@ -20,6 +20,8 @@ import {
 import { PagedAsyncIterableIterator } from "../../models/pagingTypes.js";
 import { buildPagedAsyncIterator } from "../pagingHelpers.js";
 import {
+  isUnexpected,
+  NetworkAnalyticsContext as Client,
   DataProductsAddUserRole200Response,
   DataProductsAddUserRoleDefaultResponse,
   DataProductsCreate200Response,
@@ -48,8 +50,6 @@ import {
   DataProductsUpdate202Response,
   DataProductsUpdateDefaultResponse,
   DataProductsUpdateLogicalResponse,
-  isUnexpected,
-  NetworkAnalyticsContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/dataProductsCatalogs/index.ts
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/dataProductsCatalogs/index.ts
@@ -8,14 +8,14 @@ import {
 import { PagedAsyncIterableIterator } from "../../models/pagingTypes.js";
 import { buildPagedAsyncIterator } from "../pagingHelpers.js";
 import {
+  isUnexpected,
+  NetworkAnalyticsContext as Client,
   DataProductsCatalogsGet200Response,
   DataProductsCatalogsGetDefaultResponse,
   DataProductsCatalogsListByResourceGroup200Response,
   DataProductsCatalogsListByResourceGroupDefaultResponse,
   DataProductsCatalogsListBySubscription200Response,
   DataProductsCatalogsListBySubscriptionDefaultResponse,
-  isUnexpected,
-  NetworkAnalyticsContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/dataTypes/index.ts
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/api/dataTypes/index.ts
@@ -15,6 +15,8 @@ import {
 import { PagedAsyncIterableIterator } from "../../models/pagingTypes.js";
 import { buildPagedAsyncIterator } from "../pagingHelpers.js";
 import {
+  isUnexpected,
+  NetworkAnalyticsContext as Client,
   DataTypesCreate200Response,
   DataTypesCreate201Response,
   DataTypesCreateDefaultResponse,
@@ -37,8 +39,6 @@ import {
   DataTypesUpdate202Response,
   DataTypesUpdateDefaultResponse,
   DataTypesUpdateLogicalResponse,
-  isUnexpected,
-  NetworkAnalyticsContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/rest/networkAnalyticsClient.ts
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/src/rest/networkAnalyticsClient.ts
@@ -65,5 +65,6 @@ export default function createClient(
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/api/d/index.ts
+++ b/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/src/api/d/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { A } from "../../models/models.js";
-import { DOp1204Response, FooContext as Client } from "../../rest/index.js";
+import { FooContext as Client, DOp1204Response } from "../../rest/index.js";
 import {
   StreamableMethod,
   operationOptionsToRequestParameters,

--- a/packages/typespec-test/test/loadTest/generated/typespec-ts/src/azureLoadTesting.ts
+++ b/packages/typespec-test/test/loadTest/generated/typespec-ts/src/azureLoadTesting.ts
@@ -66,5 +66,6 @@ export default function createClient(
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/api/operations.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/administrationOperations/api/operations.ts
@@ -20,6 +20,7 @@ import { PagedAsyncIterableIterator } from "../models/pagingTypes.js";
 import { buildPagedAsyncIterator } from "./pagingHelpers.js";
 import {
   isUnexpected,
+  LoadTestServiceContext as Client,
   LoadTestAdministrationCreateOrUpdateAppComponents200Response,
   LoadTestAdministrationCreateOrUpdateAppComponents201Response,
   LoadTestAdministrationCreateOrUpdateAppComponentsDefaultResponse,
@@ -47,7 +48,6 @@ import {
   LoadTestAdministrationListTestsDefaultResponse,
   LoadTestAdministrationUploadTestFile201Response,
   LoadTestAdministrationUploadTestFileDefaultResponse,
-  LoadTestServiceContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/rest/loadTestServiceClient.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/rest/loadTestServiceClient.ts
@@ -69,5 +69,6 @@ export default function createClient(
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/api/operations.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/testRunOperations/api/operations.ts
@@ -26,6 +26,7 @@ import { PagedAsyncIterableIterator } from "../models/pagingTypes.js";
 import { buildPagedAsyncIterator } from "./pagingHelpers.js";
 import {
   isUnexpected,
+  LoadTestServiceContext as Client,
   LoadTestRunCreateOrUpdateAppComponents200Response,
   LoadTestRunCreateOrUpdateAppComponents201Response,
   LoadTestRunCreateOrUpdateAppComponentsDefaultResponse,
@@ -57,7 +58,6 @@ import {
   LoadTestRunListTestRunsDefaultResponse,
   LoadTestRunStop200Response,
   LoadTestRunStopDefaultResponse,
-  LoadTestServiceContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/audio/transcriptions/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/audio/transcriptions/index.ts
@@ -6,10 +6,10 @@ import {
   CreateTranscriptionResponse,
 } from "../../../models/models.js";
 import {
-  AudioTranscriptionsCreate200Response,
-  AudioTranscriptionsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  AudioTranscriptionsCreate200Response,
+  AudioTranscriptionsCreateDefaultResponse,
 } from "../../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/audio/translations/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/audio/translations/index.ts
@@ -6,10 +6,10 @@ import {
   CreateTranslationResponse,
 } from "../../../models/models.js";
 import {
-  AudioTranslationsCreate200Response,
-  AudioTranslationsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  AudioTranslationsCreate200Response,
+  AudioTranslationsCreateDefaultResponse,
 } from "../../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/chat/completions/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/chat/completions/index.ts
@@ -8,10 +8,10 @@ import {
   CreateChatCompletionResponse,
 } from "../../../models/models.js";
 import {
-  ChatCompletionsCreate200Response,
-  ChatCompletionsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  ChatCompletionsCreate200Response,
+  ChatCompletionsCreateDefaultResponse,
 } from "../../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/completions/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/completions/index.ts
@@ -6,10 +6,10 @@ import {
   CreateCompletionResponse,
 } from "../../models/models.js";
 import {
-  CompletionsCreate200Response,
-  CompletionsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  CompletionsCreate200Response,
+  CompletionsCreateDefaultResponse,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/edits/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/edits/index.ts
@@ -3,10 +3,10 @@
 
 import { CreateEditRequest, CreateEditResponse } from "../../models/models.js";
 import {
-  EditsCreate200Response,
-  EditsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  EditsCreate200Response,
+  EditsCreateDefaultResponse,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/embeddings/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/embeddings/index.ts
@@ -6,10 +6,10 @@ import {
   CreateEmbeddingResponse,
 } from "../../models/models.js";
 import {
-  EmbeddingsCreate200Response,
-  EmbeddingsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  EmbeddingsCreate200Response,
+  EmbeddingsCreateDefaultResponse,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/files/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/files/index.ts
@@ -8,6 +8,8 @@ import {
   DeleteFileResponse,
 } from "../../models/models.js";
 import {
+  isUnexpected,
+  OpenAIContext as Client,
   FilesCreate200Response,
   FilesCreateDefaultResponse,
   FilesDelete200Response,
@@ -18,8 +20,6 @@ import {
   FilesListDefaultResponse,
   FilesRetrieve200Response,
   FilesRetrieveDefaultResponse,
-  isUnexpected,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/fineTunes/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/fineTunes/index.ts
@@ -8,6 +8,8 @@ import {
   ListFineTuneEventsResponse,
 } from "../../models/models.js";
 import {
+  isUnexpected,
+  OpenAIContext as Client,
   FineTunesCancel200Response,
   FineTunesCancelDefaultResponse,
   FineTunesCreate200Response,
@@ -18,8 +20,6 @@ import {
   FineTunesListEventsDefaultResponse,
   FineTunesRetrieve200Response,
   FineTunesRetrieveDefaultResponse,
-  isUnexpected,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/fineTuning/jobs/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/fineTuning/jobs/index.ts
@@ -8,6 +8,8 @@ import {
   ListFineTuningJobEventsResponse,
 } from "../../../models/models.js";
 import {
+  isUnexpected,
+  OpenAIContext as Client,
   FineTuningJobsCancel200Response,
   FineTuningJobsCancelDefaultResponse,
   FineTuningJobsCreate200Response,
@@ -18,8 +20,6 @@ import {
   FineTuningJobsListEventsDefaultResponse,
   FineTuningJobsRetrieve200Response,
   FineTuningJobsRetrieveDefaultResponse,
-  isUnexpected,
-  OpenAIContext as Client,
 } from "../../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/images/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/images/index.ts
@@ -8,14 +8,14 @@ import {
   CreateImageVariationRequest,
 } from "../../models/models.js";
 import {
+  isUnexpected,
+  OpenAIContext as Client,
   ImagesCreate200Response,
   ImagesCreateDefaultResponse,
   ImagesCreateEdit200Response,
   ImagesCreateEditDefaultResponse,
   ImagesCreateVariation200Response,
   ImagesCreateVariationDefaultResponse,
-  isUnexpected,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/models/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/models/index.ts
@@ -8,13 +8,13 @@ import {
 } from "../../models/models.js";
 import {
   isUnexpected,
+  OpenAIContext as Client,
   ModelsDelete200Response,
   ModelsDeleteDefaultResponse,
   ModelsList200Response,
   ModelsListDefaultResponse,
   ModelsRetrieve200Response,
   ModelsRetrieveDefaultResponse,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/moderations/index.ts
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/src/api/moderations/index.ts
@@ -7,9 +7,9 @@ import {
 } from "../../models/models.js";
 import {
   isUnexpected,
+  OpenAIContext as Client,
   ModerationsCreate200Response,
   ModerationsCreateDefaultResponse,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/api/operations.ts
+++ b/packages/typespec-test/test/openai_modular/generated/typespec-ts/src/api/operations.ts
@@ -26,6 +26,8 @@ import {
   Embeddings,
 } from "../models/models.js";
 import {
+  isUnexpected,
+  OpenAIContext as Client,
   GenerateSpeechFromText200Response,
   GenerateSpeechFromTextDefaultResponse,
   GetAudioTranscriptionAsPlainText200Response,
@@ -44,8 +46,6 @@ import {
   GetEmbeddingsDefaultResponse,
   GetImageGenerations200Response,
   GetImageGenerationsDefaultResponse,
-  isUnexpected,
-  OpenAIContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/audio/transcriptions/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/audio/transcriptions/index.ts
@@ -5,10 +5,10 @@ import {
   CreateTranscriptionResponse,
 } from "../../../models/models.js";
 import {
-  AudioTranscriptionsCreate200Response,
-  AudioTranscriptionsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  AudioTranscriptionsCreate200Response,
+  AudioTranscriptionsCreateDefaultResponse,
 } from "../../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/audio/translations/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/audio/translations/index.ts
@@ -5,10 +5,10 @@ import {
   CreateTranslationResponse,
 } from "../../../models/models.js";
 import {
-  AudioTranslationsCreate200Response,
-  AudioTranslationsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  AudioTranslationsCreate200Response,
+  AudioTranslationsCreateDefaultResponse,
 } from "../../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/chat/completions/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/chat/completions/index.ts
@@ -7,10 +7,10 @@ import {
   CreateChatCompletionResponse,
 } from "../../../models/models.js";
 import {
-  ChatCompletionsCreate200Response,
-  ChatCompletionsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  ChatCompletionsCreate200Response,
+  ChatCompletionsCreateDefaultResponse,
 } from "../../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/completions/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/completions/index.ts
@@ -5,10 +5,10 @@ import {
   CreateCompletionResponse,
 } from "../../models/models.js";
 import {
-  CompletionsCreate200Response,
-  CompletionsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  CompletionsCreate200Response,
+  CompletionsCreateDefaultResponse,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/edits/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/edits/index.ts
@@ -2,10 +2,10 @@
 
 import { CreateEditRequest, CreateEditResponse } from "../../models/models.js";
 import {
-  EditsCreate200Response,
-  EditsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  EditsCreate200Response,
+  EditsCreateDefaultResponse,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/embeddings/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/embeddings/index.ts
@@ -5,10 +5,10 @@ import {
   CreateEmbeddingResponse,
 } from "../../models/models.js";
 import {
-  EmbeddingsCreate200Response,
-  EmbeddingsCreateDefaultResponse,
   isUnexpected,
   OpenAIContext as Client,
+  EmbeddingsCreate200Response,
+  EmbeddingsCreateDefaultResponse,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/files/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/files/index.ts
@@ -7,6 +7,8 @@ import {
   DeleteFileResponse,
 } from "../../models/models.js";
 import {
+  isUnexpected,
+  OpenAIContext as Client,
   FilesCreate200Response,
   FilesCreateDefaultResponse,
   FilesDelete200Response,
@@ -17,8 +19,6 @@ import {
   FilesListDefaultResponse,
   FilesRetrieve200Response,
   FilesRetrieveDefaultResponse,
-  isUnexpected,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/fineTunes/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/fineTunes/index.ts
@@ -7,6 +7,8 @@ import {
   ListFineTuneEventsResponse,
 } from "../../models/models.js";
 import {
+  isUnexpected,
+  OpenAIContext as Client,
   FineTunesCancel200Response,
   FineTunesCancelDefaultResponse,
   FineTunesCreate200Response,
@@ -17,8 +19,6 @@ import {
   FineTunesListEventsDefaultResponse,
   FineTunesRetrieve200Response,
   FineTunesRetrieveDefaultResponse,
-  isUnexpected,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/fineTuning/jobs/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/fineTuning/jobs/index.ts
@@ -7,6 +7,8 @@ import {
   ListFineTuningJobEventsResponse,
 } from "../../../models/models.js";
 import {
+  isUnexpected,
+  OpenAIContext as Client,
   FineTuningJobsCancel200Response,
   FineTuningJobsCancelDefaultResponse,
   FineTuningJobsCreate200Response,
@@ -17,8 +19,6 @@ import {
   FineTuningJobsListEventsDefaultResponse,
   FineTuningJobsRetrieve200Response,
   FineTuningJobsRetrieveDefaultResponse,
-  isUnexpected,
-  OpenAIContext as Client,
 } from "../../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/images/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/images/index.ts
@@ -7,14 +7,14 @@ import {
   CreateImageVariationRequest,
 } from "../../models/models.js";
 import {
+  isUnexpected,
+  OpenAIContext as Client,
   ImagesCreate200Response,
   ImagesCreateDefaultResponse,
   ImagesCreateEdit200Response,
   ImagesCreateEditDefaultResponse,
   ImagesCreateVariation200Response,
   ImagesCreateVariationDefaultResponse,
-  isUnexpected,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/models/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/models/index.ts
@@ -7,13 +7,13 @@ import {
 } from "../../models/models.js";
 import {
   isUnexpected,
+  OpenAIContext as Client,
   ModelsDelete200Response,
   ModelsDeleteDefaultResponse,
   ModelsList200Response,
   ModelsListDefaultResponse,
   ModelsRetrieve200Response,
   ModelsRetrieveDefaultResponse,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/moderations/index.ts
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/src/api/moderations/index.ts
@@ -6,9 +6,9 @@ import {
 } from "../../models/models.js";
 import {
   isUnexpected,
+  OpenAIContext as Client,
   ModerationsCreate200Response,
   ModerationsCreateDefaultResponse,
-  OpenAIContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/api/fooOperations/index.ts
+++ b/packages/typespec-test/test/overloads_modular/generated/typespec-ts/src/api/fooOperations/index.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 
 import {
+  isUnexpected,
+  WidgetManagerContext as Client,
   GetAvatarAsJpeg204Response,
   GetAvatarAsJpegDefaultResponse,
   GetAvatarAsPng204Response,
   GetAvatarAsPngDefaultResponse,
-  isUnexpected,
-  WidgetManagerContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/api/confidentialLedger/index.ts
+++ b/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/src/api/confidentialLedger/index.ts
@@ -4,9 +4,9 @@
 import { Collection } from "../../models/models.js";
 import {
   isUnexpected,
+  ParametrizedHostContext as Client,
   ListCollections200Response,
   ListCollectionsDefaultResponse,
-  ParametrizedHostContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/api/schemaOperations/index.ts
+++ b/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/src/api/schemaOperations/index.ts
@@ -11,20 +11,20 @@ import {
 import { PagedAsyncIterableIterator } from "../../models/pagingTypes.js";
 import { buildPagedAsyncIterator } from "../pagingHelpers.js";
 import {
+  isUnexpected,
+  SchemaRegistryContext as Client,
   GetSchemaById200Response,
   GetSchemaByIdDefaultResponse,
   GetSchemaByVersion200Response,
   GetSchemaByVersionDefaultResponse,
   GetSchemaIdByContent204Response,
   GetSchemaIdByContentDefaultResponse,
-  isUnexpected,
   ListSchemaGroups200Response,
   ListSchemaGroupsDefaultResponse,
   ListSchemaVersions200Response,
   ListSchemaVersionsDefaultResponse,
   RegisterSchema204Response,
   RegisterSchemaDefaultResponse,
-  SchemaRegistryContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/api/budgets/index.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/api/budgets/index.ts
@@ -5,12 +5,12 @@ import { getLongRunningPoller } from "../pollingHelpers.js";
 import { PollerLike, OperationState } from "@azure/core-lro";
 import { User } from "../../models/models.js";
 import {
+  isUnexpected,
+  WidgetServiceContext as Client,
   BudgetsCreateOrReplace200Response,
   BudgetsCreateOrReplace201Response,
   BudgetsCreateOrReplaceDefaultResponse,
   BudgetsCreateOrReplaceLogicalResponse,
-  isUnexpected,
-  WidgetServiceContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/api/widgets/index.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/src/api/widgets/index.ts
@@ -12,8 +12,9 @@ import {
 import { PagedAsyncIterableIterator } from "../../models/pagingTypes.js";
 import { buildPagedAsyncIterator } from "../pagingHelpers.js";
 import {
-  buildCsvCollection,
   isUnexpected,
+  WidgetServiceContext as Client,
+  buildCsvCollection,
   WidgetsAnalyzeWidget200Response,
   WidgetsAnalyzeWidgetDefaultResponse,
   WidgetsCreateOrReplace200Response,
@@ -24,7 +25,6 @@ import {
   WidgetsCreateWidgetDefaultResponse,
   WidgetsDeleteWidget204Response,
   WidgetsDeleteWidgetDefaultResponse,
-  WidgetServiceContext as Client,
   WidgetsGetWidget200Response,
   WidgetsGetWidgetDefaultResponse,
   WidgetsListWidgets200Response,

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -119,7 +119,7 @@
     "fs-extra": "^11.1.0",
     "lodash": "^4.17.21",
     "prettier": "^3.1.0",
-    "ts-morph": "^15.1.0",
+    "ts-morph": "^23.0.0",
     "tslib": "^2.3.1"
   },
   "files": [

--- a/packages/typespec-ts/test/integration/generated/azure/core/basic/src/azureCoreClient.ts
+++ b/packages/typespec-ts/test/integration/generated/azure/core/basic/src/azureCoreClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/integration/generated/azure/core/lro/rpc/src/rpcClient.ts
+++ b/packages/typespec-ts/test/integration/generated/azure/core/lro/rpc/src/rpcClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/integration/generated/azure/core/lro/standard/src/standardClient.ts
+++ b/packages/typespec-ts/test/integration/generated/azure/core/lro/standard/src/standardClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/integration/generated/azure/core/traits/src/azureCoreTraitsClient.ts
+++ b/packages/typespec-ts/test/integration/generated/azure/core/traits/src/azureCoreTraitsClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/integration/generated/azure/resource-manager/models/common-types/managed-identity/src/azureArmModelsCommonTypesManagedIdentity.ts
+++ b/packages/typespec-ts/test/integration/generated/azure/resource-manager/models/common-types/managed-identity/src/azureArmModelsCommonTypesManagedIdentity.ts
@@ -57,5 +57,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/integration/generated/azure/resource-manager/models/resources/src/azureArmResourceClient.ts
+++ b/packages/typespec-ts/test/integration/generated/azure/resource-manager/models/resources/src/azureArmResourceClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/authentication/oauth2/src/api/operations.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  OAuth2Context as Client,
   Invalid204Response,
   Invalid403Response,
-  OAuth2Context as Client,
   Valid204Response,
 } from "../rest/index.js";
 import {

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/client-generator-core/usage/src/api/operations.ts
@@ -3,10 +3,10 @@
 
 import { InputModel, OutputModel, RoundTripModel } from "../models/models.js";
 import {
+  UsageContext as Client,
   InputToInputOutput204Response,
   ModelInReadOnlyProperty200Response,
   OutputToInputOutput200Response,
-  UsageContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/rest/basicClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/basic/src/rest/basicClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/api/operations.ts
@@ -6,10 +6,10 @@ import { PollerLike, OperationState } from "@azure/core-lro";
 import { GenerationOptions, GenerationResult } from "../models/models.js";
 import {
   isUnexpected,
+  RpcContext as Client,
   LongRunningRpc202Response,
   LongRunningRpcDefaultResponse,
   LongRunningRpcLogicalResponse,
-  RpcContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/rest/rpcClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/rpc/generated/src/rest/rpcClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/api/operations.ts
@@ -5,6 +5,8 @@ import { getLongRunningPoller } from "./pollingHelpers.js";
 import { PollerLike, OperationState } from "@azure/core-lro";
 import { User, ExportedUser } from "../models/models.js";
 import {
+  isUnexpected,
+  StandardContext as Client,
   CreateOrReplace200Response,
   CreateOrReplace201Response,
   CreateOrReplaceDefaultResponse,
@@ -15,8 +17,6 @@ import {
   Export202Response,
   ExportDefaultResponse,
   ExportLogicalResponse,
-  isUnexpected,
-  StandardContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/rest/standardClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/lro/standard/generated/src/rest/standardClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/model/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/model/src/api/operations.ts
@@ -3,8 +3,8 @@
 
 import { AzureEmbeddingModel } from "../models/models.js";
 import {
-  Get200Response,
   ModelContext as Client,
+  Get200Response,
   Post200Response,
   Put204Response,
 } from "../rest/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/scalar/src/api/operations.ts
@@ -3,12 +3,12 @@
 
 import { AzureLocationModel } from "../models/models.js";
 import {
+  ScalarContext as Client,
   Get200Response,
   Header204Response,
   Post200Response,
   Put204Response,
   Query204Response,
-  ScalarContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/api/operations.ts
@@ -4,11 +4,11 @@
 import { User, UserActionParam, UserActionResponse } from "../models/models.js";
 import {
   isUnexpected,
+  TraitsContext as Client,
   RepeatableAction200Response,
   RepeatableActionDefaultResponse,
   SmokeTest200Response,
   SmokeTestDefaultResponse,
-  TraitsContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/rest/traitsClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/core/traits/src/rest/traitsClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/common-types/managed-identity/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/common-types/managed-identity/src/api/operations.ts
@@ -7,13 +7,13 @@ import {
   ManagedIdentityTrackedResource,
 } from "../models/models.js";
 import {
+  isUnexpected,
+  ManagedIdentityContext as Client,
   CreateWithSystemAssigned200Response,
   CreateWithSystemAssigned201Response,
   CreateWithSystemAssignedDefaultResponse,
   Get200Response,
   GetDefaultResponse,
-  isUnexpected,
-  ManagedIdentityContext as Client,
   UpdateWithUserAssignedAndSystemAssigned200Response,
   UpdateWithUserAssignedAndSystemAssignedDefaultResponse,
 } from "../rest/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/common-types/managed-identity/src/rest/managedIdentityClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/common-types/managed-identity/src/rest/managedIdentityClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/api/nestedProxyResources/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/api/nestedProxyResources/index.ts
@@ -12,6 +12,7 @@ import { PagedAsyncIterableIterator } from "../../models/pagingTypes.js";
 import { buildPagedAsyncIterator } from "../pagingHelpers.js";
 import {
   isUnexpected,
+  ResourcesContext as Client,
   NestedProxyResourcesCreateOrReplace200Response,
   NestedProxyResourcesCreateOrReplace201Response,
   NestedProxyResourcesCreateOrReplaceDefaultResponse,
@@ -28,7 +29,6 @@ import {
   NestedProxyResourcesUpdate202Response,
   NestedProxyResourcesUpdateDefaultResponse,
   NestedProxyResourcesUpdateLogicalResponse,
-  ResourcesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/rest/resourcesClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/resource-manager/models/resources/src/rest/resourcesClient.ts
@@ -53,5 +53,6 @@ export default function createClient({
       return next(req);
     },
   });
+
   return client;
 }

--- a/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/azure/special-headers/client-request-id/src/api/operations.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  Get204Response,
   XmsRequestIdClientContext as Client,
+  Get204Response,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/api/clientModel/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/api/clientModel/index.ts
@@ -3,9 +3,9 @@
 
 import { ClientModel, TSModel } from "../../models/models.js";
 import {
+  NamingContext as Client,
   ModelClient204Response,
   ModelLanguage204Response,
-  NamingContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/naming/src/api/operations.ts
@@ -7,9 +7,9 @@ import {
   ClientNameAndJsonEncodedNameModel,
 } from "../models/models.js";
 import {
+  NamingContext as Client,
   HeaderRequest204Response,
   HeaderResponse204Response,
-  NamingContext as Client,
   Operation204Response,
   Parameter204Response,
   PropertyClient204Response,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/bar/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/bar/index.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  Five204Response,
   ServiceContext as Client,
+  Five204Response,
   Six204Response,
 } from "../../rest/index.js";
 import {

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/foo/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/foo/index.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  Four204Response,
   ServiceContext as Client,
+  Four204Response,
   Three204Response,
 } from "../../rest/index.js";
 import {

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/operations.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  One204Response,
   ServiceContext as Client,
+  One204Response,
   Two204Response,
 } from "../rest/index.js";
 import {

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/qux/bar/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/qux/bar/index.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  Nine204Response,
   ServiceContext as Client,
+  Nine204Response,
 } from "../../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/qux/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/default/src/api/qux/index.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  Eight204Response,
   ServiceContext as Client,
+  Eight204Response,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/a/api/operations.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  ServiceContext as Client,
   Five204Response,
   One204Response,
-  ServiceContext as Client,
   Three204Response,
 } from "../../rest/index.js";
 import {

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/multi-client/src/b/api/operations.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  Four204Response,
   ServiceContext as Client,
+  Four204Response,
   Six204Response,
   Two204Response,
 } from "../../rest/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/api/group/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/api/group/index.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  Four204Response,
   ServiceContext as Client,
+  Four204Response,
   Six204Response,
   Two204Response,
 } from "../../rest/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/renamed-operation/src/api/operations.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  ServiceContext as Client,
   Five204Response,
   One204Response,
-  ServiceContext as Client,
   Three204Response,
 } from "../rest/index.js";
 import {

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/api/group1/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/api/group1/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  ServiceContext as Client,
   Four204Response,
   One204Response,
-  ServiceContext as Client,
   Three204Response,
 } from "../../rest/index.js";
 import {

--- a/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/api/group2/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/client/structure/two-operation-group/src/api/group2/index.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  Five204Response,
   ServiceContext as Client,
+  Five204Response,
   Six204Response,
   Two204Response,
 } from "../../rest/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/api/model/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/spread/src/api/model/index.ts
@@ -3,12 +3,12 @@
 
 import { BodyParameter } from "../../models/models.js";
 import {
+  SpreadContext as Client,
   ModelSpreadAsRequestBody204Response,
   ModelSpreadCompositeRequest204Response,
   ModelSpreadCompositeRequestMix204Response,
   ModelSpreadCompositeRequestOnlyWithBody204Response,
   ModelSpreadCompositeRequestWithoutBody204Response,
-  SpreadContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/api/stringBody/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/media-type/src/api/stringBody/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  MediaTypeContext as Client,
   GetAsJson200Response,
   GetAsText200Response,
-  MediaTypeContext as Client,
   SendAsJson200Response,
   SendAsText200Response,
 } from "../../rest/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/payload/pageable/src/api/operations.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { User, _PagedUser } from "../models/models.js";
+import { _PagedUser, User } from "../models/models.js";
 import { PagedAsyncIterableIterator } from "../models/pagingTypes.js";
 import { buildPagedAsyncIterator } from "./pagingHelpers.js";
-import { List200Response, PageableContext as Client } from "../rest/index.js";
+import { PageableContext as Client, List200Response } from "../rest/index.js";
 import {
   StreamableMethod,
   operationOptionsToRequestParameters,

--- a/packages/typespec-ts/test/modularIntegration/generated/resiliency/srv-driven-main/generated/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/resiliency/srv-driven-main/generated/src/api/operations.ts
@@ -3,10 +3,10 @@
 
 import {
   AddOperation204Response,
+  ServiceDrivenContext as Client,
   FromNone204Response,
   FromOneOptional204Response,
   FromOneRequired204Response,
-  ServiceDrivenContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/resiliency/srv-driven-old/generated/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/resiliency/srv-driven-old/generated/src/api/operations.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
+  ServiceDrivenContext as Client,
   FromNone204Response,
   FromOneOptional204Response,
   FromOneRequired204Response,
-  ServiceDrivenContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/serialization/encoded-name/json/src/api/operations.ts
@@ -3,8 +3,8 @@
 
 import { JsonEncodedNameModel } from "../models/models.js";
 import {
-  Get200Response,
   JsonContext as Client,
+  Get200Response,
   Send204Response,
 } from "../rest/index.js";
 import {

--- a/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/server/path/single/src/api/operations.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { MyOp200Response, SingleContext as Client } from "../rest/index.js";
+import { SingleContext as Client, MyOp200Response } from "../rest/index.js";
 import {
   StreamableMethod,
   operationOptionsToRequestParameters,

--- a/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-headers/repeatability/generated/src/api/operations.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 import {
-  ImmediateSuccess204Response,
   RepeatabilityContext as Client,
+  ImmediateSuccess204Response,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/modelProperties/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/modelProperties/index.ts
@@ -3,8 +3,8 @@
 
 import { SameAsModel } from "../../models/models.js";
 import {
-  ModelPropertiesSameAsModel204Response,
   SpecialWordsContext as Client,
+  ModelPropertiesSameAsModel204Response,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/models/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/models/index.ts
@@ -37,6 +37,7 @@ import {
   Yield,
 } from "../../models/models.js";
 import {
+  SpecialWordsContext as Client,
   ModelsWithAnd204Response,
   ModelsWithAs204Response,
   ModelsWithAssert204Response,
@@ -70,7 +71,6 @@ import {
   ModelsWithWhile204Response,
   ModelsWithWith204Response,
   ModelsWithYield204Response,
-  SpecialWordsContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/operations/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/operations/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import {
+  SpecialWordsContext as Client,
   OperationsAnd204Response,
   OperationsAs204Response,
   OperationsAssert204Response,
@@ -35,7 +36,6 @@ import {
   OperationsWhile204Response,
   OperationsWith204Response,
   OperationsYield204Response,
-  SpecialWordsContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/parameters/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/special-words/src/api/parameters/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import {
+  SpecialWordsContext as Client,
   ParametersWithAnd204Response,
   ParametersWithAs204Response,
   ParametersWithAssert204Response,
@@ -36,7 +37,6 @@ import {
   ParametersWithWhile204Response,
   ParametersWithWith204Response,
   ParametersWithYield204Response,
-  SpecialWordsContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/array/src/api/booleanValue/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/array/src/api/booleanValue/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
-  ArrayContext as Client,
   BooleanValueGet200Response,
   BooleanValuePut204Response,
+  ArrayContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/api/datetimeValue/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/src/api/datetimeValue/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  DictionaryContext as Client,
   DatetimeValueGet200Response,
   DatetimeValuePut204Response,
-  DictionaryContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/nested-discriminator/src/api/operations.ts
@@ -3,11 +3,11 @@
 
 import { fishUnionSerializer, FishUnion } from "../models/models.js";
 import {
+  NestedDiscriminatorContext as Client,
   GetMissingDiscriminator200Response,
   GetModel200Response,
   GetRecursiveModel200Response,
   GetWrongDiscriminator200Response,
-  NestedDiscriminatorContext as Client,
   PutModel204Response,
   PutRecursiveModel204Response,
 } from "../rest/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/not-discriminated/src/api/operations.ts
@@ -3,8 +3,8 @@
 
 import { Siamese } from "../models/models.js";
 import {
-  GetValid200Response,
   NotDiscriminatedContext as Client,
+  GetValid200Response,
   PostValid204Response,
   PutValid200Response,
 } from "../rest/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/recursive/generated/src/api/operations.ts
@@ -3,9 +3,9 @@
 
 import { extensionSerializer, Extension } from "../models/models.js";
 import {
+  RecursiveContext as Client,
   Get200Response,
   Put204Response,
-  RecursiveContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/inheritance/single-discriminator/src/api/operations.ts
@@ -7,6 +7,7 @@ import {
   DinosaurUnion,
 } from "../models/models.js";
 import {
+  SingleDiscriminatorContext as Client,
   GetLegacyModel200Response,
   GetMissingDiscriminator200Response,
   GetModel200Response,
@@ -14,7 +15,6 @@ import {
   GetWrongDiscriminator200Response,
   PutModel204Response,
   PutRecursiveModel204Response,
-  SingleDiscriminatorContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/model/usage/generated/src/api/operations.ts
@@ -7,10 +7,10 @@ import {
   InputOutputRecord,
 } from "../models/models.js";
 import {
+  UsageContext as Client,
   Input204Response,
   InputAndOutput200Response,
   Output200Response,
-  UsageContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/collectionsByte/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/collectionsByte/index.ts
@@ -3,11 +3,11 @@
 
 import { CollectionsByteProperty } from "../../models/models.js";
 import {
+  NullableContext as Client,
   CollectionsByteGetNonNull200Response,
   CollectionsByteGetNull200Response,
   CollectionsBytePatchNonNull204Response,
   CollectionsBytePatchNull204Response,
-  NullableContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/collectionsModel/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/collectionsModel/index.ts
@@ -6,11 +6,11 @@ import {
   CollectionsModelProperty,
 } from "../../models/models.js";
 import {
+  NullableContext as Client,
   CollectionsModelGetNonNull200Response,
   CollectionsModelGetNull200Response,
   CollectionsModelPatchNonNull204Response,
   CollectionsModelPatchNull204Response,
-  NullableContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/collectionsString/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/collectionsString/index.ts
@@ -3,11 +3,11 @@
 
 import { CollectionsStringProperty } from "../../models/models.js";
 import {
+  NullableContext as Client,
   CollectionsStringGetNonNull200Response,
   CollectionsStringGetNull200Response,
   CollectionsStringPatchNonNull204Response,
   CollectionsStringPatchNull204Response,
-  NullableContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/datetime/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/datetime/index.ts
@@ -3,11 +3,11 @@
 
 import { DatetimeProperty } from "../../models/models.js";
 import {
+  NullableContext as Client,
   DatetimeGetNonNull200Response,
   DatetimeGetNull200Response,
   DatetimePatchNonNull204Response,
   DatetimePatchNull204Response,
-  NullableContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/duration/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/src/api/duration/index.ts
@@ -3,11 +3,11 @@
 
 import { DurationProperty } from "../../models/models.js";
 import {
+  NullableContext as Client,
   DurationGetNonNull200Response,
   DurationGetNull200Response,
   DurationPatchNonNull204Response,
   DurationPatchNull204Response,
-  NullableContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/collectionsByte/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/collectionsByte/index.ts
@@ -3,11 +3,11 @@
 
 import { CollectionsByteProperty } from "../../models/models.js";
 import {
+  OptionalContext as Client,
   CollectionsByteGetAll200Response,
   CollectionsByteGetDefault200Response,
   CollectionsBytePutAll204Response,
   CollectionsBytePutDefault204Response,
-  OptionalContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/collectionsModel/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/collectionsModel/index.ts
@@ -6,11 +6,11 @@ import {
   CollectionsModelProperty,
 } from "../../models/models.js";
 import {
+  OptionalContext as Client,
   CollectionsModelGetAll200Response,
   CollectionsModelGetDefault200Response,
   CollectionsModelPutAll204Response,
   CollectionsModelPutDefault204Response,
-  OptionalContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/datetime/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/datetime/index.ts
@@ -3,11 +3,11 @@
 
 import { DatetimeProperty } from "../../models/models.js";
 import {
+  OptionalContext as Client,
   DatetimeGetAll200Response,
   DatetimeGetDefault200Response,
   DatetimePutAll204Response,
   DatetimePutDefault204Response,
-  OptionalContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/duration/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/duration/index.ts
@@ -3,11 +3,11 @@
 
 import { DurationProperty } from "../../models/models.js";
 import {
+  OptionalContext as Client,
   DurationGetAll200Response,
   DurationGetDefault200Response,
   DurationPutAll204Response,
   DurationPutDefault204Response,
-  OptionalContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/floatLiteral/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/floatLiteral/index.ts
@@ -3,11 +3,11 @@
 
 import { FloatLiteralProperty } from "../../models/models.js";
 import {
+  OptionalContext as Client,
   FloatLiteralGetAll200Response,
   FloatLiteralGetDefault200Response,
   FloatLiteralPutAll204Response,
   FloatLiteralPutDefault204Response,
-  OptionalContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/intLiteral/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/src/api/intLiteral/index.ts
@@ -3,11 +3,11 @@
 
 import { IntLiteralProperty } from "../../models/models.js";
 import {
+  OptionalContext as Client,
   IntLiteralGetAll200Response,
   IntLiteralGetDefault200Response,
   IntLiteralPutAll204Response,
   IntLiteralPutDefault204Response,
-  OptionalContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/collectionsInt/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/collectionsInt/index.ts
@@ -3,9 +3,9 @@
 
 import { CollectionsIntProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   CollectionsIntGet200Response,
   CollectionsIntPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/collectionsModel/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/collectionsModel/index.ts
@@ -6,9 +6,9 @@ import {
   CollectionsModelProperty,
 } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   CollectionsModelGet200Response,
   CollectionsModelPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/collectionsString/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/collectionsString/index.ts
@@ -3,9 +3,9 @@
 
 import { CollectionsStringProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   CollectionsStringGet200Response,
   CollectionsStringPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/datetime/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/datetime/index.ts
@@ -3,9 +3,9 @@
 
 import { DatetimeProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   DatetimeGet200Response,
   DatetimePut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/decimal/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/decimal/index.ts
@@ -3,9 +3,9 @@
 
 import { DecimalProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   DecimalGet200Response,
   DecimalPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/decimal128/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/decimal128/index.ts
@@ -3,9 +3,9 @@
 
 import { Decimal128Property } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   Decimal128Get200Response,
   Decimal128Put204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/dictionaryString/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/dictionaryString/index.ts
@@ -3,9 +3,9 @@
 
 import { DictionaryStringProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   DictionaryStringGet200Response,
   DictionaryStringPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/duration/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/duration/index.ts
@@ -3,9 +3,9 @@
 
 import { DurationProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   DurationGet200Response,
   DurationPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/enum/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/enum/index.ts
@@ -3,9 +3,9 @@
 
 import { EnumProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   EnumGet200Response,
   EnumPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/extensibleEnum/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/extensibleEnum/index.ts
@@ -3,9 +3,9 @@
 
 import { ExtensibleEnumProperty, InnerEnum } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   ExtensibleEnumGet200Response,
   ExtensibleEnumPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/float/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/float/index.ts
@@ -3,9 +3,9 @@
 
 import { FloatProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   FloatGet200Response,
   FloatPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/floatLiteral/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/floatLiteral/index.ts
@@ -3,9 +3,9 @@
 
 import { FloatLiteralProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   FloatLiteralGet200Response,
   FloatLiteralPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/int/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/int/index.ts
@@ -3,9 +3,9 @@
 
 import { IntProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   IntGet200Response,
   IntPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/intLiteral/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/intLiteral/index.ts
@@ -3,9 +3,9 @@
 
 import { IntLiteralProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   IntLiteralGet200Response,
   IntLiteralPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/model/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/model/index.ts
@@ -3,9 +3,9 @@
 
 import { innerModelSerializer, ModelProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   ModelGet200Response,
   ModelPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/never/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/never/index.ts
@@ -3,9 +3,9 @@
 
 import { NeverProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   NeverGet200Response,
   NeverPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/string/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/string/index.ts
@@ -3,9 +3,9 @@
 
 import { StringProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   StringModelGet200Response,
   StringModelPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/stringLiteral/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/stringLiteral/index.ts
@@ -3,9 +3,9 @@
 
 import { StringLiteralProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   StringLiteralGet200Response,
   StringLiteralPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unionEnumValue/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unionEnumValue/index.ts
@@ -3,9 +3,9 @@
 
 import { UnionEnumValueProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   UnionEnumValueGet200Response,
   UnionEnumValuePut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unionFloatLiteral/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unionFloatLiteral/index.ts
@@ -3,9 +3,9 @@
 
 import { UnionFloatLiteralProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   UnionFloatLiteralGet200Response,
   UnionFloatLiteralPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unionIntLiteral/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unionIntLiteral/index.ts
@@ -3,9 +3,9 @@
 
 import { UnionIntLiteralProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   UnionIntLiteralGet200Response,
   UnionIntLiteralPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unionStringLiteral/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unionStringLiteral/index.ts
@@ -3,9 +3,9 @@
 
 import { UnionStringLiteralProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   UnionStringLiteralGet200Response,
   UnionStringLiteralPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unknownArray/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unknownArray/index.ts
@@ -3,9 +3,9 @@
 
 import { UnknownArrayProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   UnknownArrayGet200Response,
   UnknownArrayPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unknownDict/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unknownDict/index.ts
@@ -3,9 +3,9 @@
 
 import { UnknownDictProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   UnknownDictGet200Response,
   UnknownDictPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unknownInt/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unknownInt/index.ts
@@ -3,9 +3,9 @@
 
 import { UnknownIntProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   UnknownIntGet200Response,
   UnknownIntPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unknownString/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/value-types/generated/src/api/unknownString/index.ts
@@ -3,9 +3,9 @@
 
 import { UnknownStringProperty } from "../../models/models.js";
 import {
+  ValueTypesContext as Client,
   UnknownStringGet200Response,
   UnknownStringPut204Response,
-  ValueTypesContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/decimal128Type/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/decimal128Type/index.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
+  ScalarContext as Client,
   Decimal128TypeRequestBody204Response,
   Decimal128TypeRequestParameter204Response,
   Decimal128TypeResponseBody200Response,
-  ScalarContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/decimal128Verify/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/decimal128Verify/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  ScalarContext as Client,
   Decimal128VerifyPrepareVerify200Response,
   Decimal128VerifyVerify204Response,
-  ScalarContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/decimalType/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/decimalType/index.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
+  ScalarContext as Client,
   DecimalTypeRequestBody204Response,
   DecimalTypeRequestParameter204Response,
   DecimalTypeResponseBody200Response,
-  ScalarContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/decimalVerify/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/scalar/src/api/decimalVerify/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  ScalarContext as Client,
   DecimalVerifyPrepareVerify200Response,
   DecimalVerifyVerify204Response,
-  ScalarContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/enumsOnly/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/enumsOnly/index.ts
@@ -3,9 +3,9 @@
 
 import { EnumsOnlyCases } from "../../models/models.js";
 import {
+  UnionContext as Client,
   EnumsOnlyGet200Response,
   EnumsOnlySend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/floatsOnly/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/floatsOnly/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  UnionContext as Client,
   FloatsOnlyGet200Response,
   FloatsOnlySend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/intsOnly/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/intsOnly/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  UnionContext as Client,
   IntsOnlyGet200Response,
   IntsOnlySend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/mixedLiterals/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/mixedLiterals/index.ts
@@ -3,9 +3,9 @@
 
 import { MixedLiteralsCases } from "../../models/models.js";
 import {
+  UnionContext as Client,
   MixedLiteralsGet200Response,
   MixedLiteralsSend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/mixedTypes/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/mixedTypes/index.ts
@@ -3,9 +3,9 @@
 
 import { MixedTypesCases } from "../../models/models.js";
 import {
+  UnionContext as Client,
   MixedTypesGet200Response,
   MixedTypesSend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/modelsOnly/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/modelsOnly/index.ts
@@ -3,9 +3,9 @@
 
 import { Cat, Dog } from "../../models/models.js";
 import {
+  UnionContext as Client,
   ModelsOnlyGet200Response,
   ModelsOnlySend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/stringAndArray/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/stringAndArray/index.ts
@@ -3,9 +3,9 @@
 
 import { StringAndArrayCases } from "../../models/models.js";
 import {
+  UnionContext as Client,
   StringAndArrayGet200Response,
   StringAndArraySend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/stringExtensible/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/stringExtensible/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  UnionContext as Client,
   StringExtensibleGet200Response,
   StringExtensibleSend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/stringExtensibleNamed/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/stringExtensibleNamed/index.ts
@@ -3,9 +3,9 @@
 
 import { StringExtensibleNamedUnion } from "../../models/models.js";
 import {
+  UnionContext as Client,
   StringExtensibleNamedGet200Response,
   StringExtensibleNamedSend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/stringsOnly/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/union/src/api/stringsOnly/index.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  UnionContext as Client,
   StringsOnlyGet200Response,
   StringsOnlySend204Response,
-  UnionContext as Client,
 } from "../../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/renamedFrom/src/api/operations.ts
@@ -3,9 +3,9 @@
 
 import { NewModel } from "../models/models.js";
 import {
+  RenamedFromContext as Client,
   NewOp200Response,
   NewOpInNewInterface200Response,
-  RenamedFromContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/versioning/typeChangedFrom/src/api/operations.ts
@@ -3,8 +3,8 @@
 
 import { TestModel } from "../models/models.js";
 import {
-  Test200Response,
   TypeChangedFromContext as Client,
+  Test200Response,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/api/operations.ts
+++ b/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/api/operations.ts
@@ -6,10 +6,10 @@ import {
   InputOutputRecord,
 } from "../models/models.js";
 import {
+  UsageContext as Client,
   Input204Response,
   InputAndOutput200Response,
   Output200Response,
-  UsageContext as Client,
 } from "../rest/index.js";
 import {
   StreamableMethod,

--- a/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/rest/usageClient.ts
+++ b/packages/typespec-ts/test/nonBrandedIntegration/modular/generated/models/usage/src/rest/usageClient.ts
@@ -29,5 +29,6 @@ export default function createClient(
   const client = getClient(endpointUrl, options) as UsageContext;
 
   client.pipeline.removePolicy({ name: "ApiVersionPolicy" });
+
   return client;
 }

--- a/packages/typespec-ts/test/nonBrandedIntegration/rlc/generated/models/usage/src/usageClient.ts
+++ b/packages/typespec-ts/test/nonBrandedIntegration/rlc/generated/models/usage/src/usageClient.ts
@@ -29,5 +29,6 @@ export default function createClient(
   const client = getClient(endpointUrl, options) as UsageClient;
 
   client.pipeline.removePolicy({ name: "ApiVersionPolicy" });
+
   return client;
 }


### PR DESCRIPTION
Pulls in [dsherret/code-block-writer#50](https://github.com/dsherret/code-block-writer/pull/50) to fix emitting string literals containing `/*`

Fixes #2585 