### PR TITLE
Binder support external dependencies

### DIFF
--- a/packages/typespec-ts/src/azure/dependency.ts
+++ b/packages/typespec-ts/src/azure/dependency.ts
@@ -1,0 +1,59 @@
+import { CoreDependencies } from "../framework/dependency.js";
+
+export const AzureCoreDependencies: CoreDependencies = {
+  Client: {
+    kind: "externalDependency",
+    module: "@azure-rest/core-client",
+    name: "Client"
+  },
+  ClientOptions: {
+    kind: "externalDependency",
+    module: "@azure-rest/core-client",
+    name: "ClientOptions"
+  },
+  Pipeline: {
+    kind: "externalDependency",
+    module: "@azure-rest/core-client",
+    name: "Pipeline"
+  },
+  getClient: {
+    kind: "externalDependency",
+    module: "@azure-rest/core-client",
+    name: "getClient"
+  },
+  RestError: {
+    kind: "externalDependency",
+    module: "@azure-rest/core-client",
+    name: "RestError"
+  },
+  OperationOptions: {
+    kind: "externalDependency",
+    module: "@azure-rest/core-client",
+    name: "OperationOptions"
+  },
+  PathUnckeckedResponse: {
+    kind: "externalDependency",
+    module: "@azure-rest/core-client",
+    name: "PathUnckeckedResponse"
+  },
+  AbortSignalLike: {
+    kind: "externalDependency",
+    module: "@azure/abort-controller",
+    name: "AbortSignalLike"
+  },
+  createRestError: {
+    kind: "externalDependency",
+    module: "@azure-rest/core-client",
+    name: "createRestError"
+  },
+  operationOptionsToRequestParameters: {
+    kind: "externalDependency",
+    module: "@azure-rest/core-client",
+    name: "operationOptionsToRequestParameters"
+  },
+  uint8ArrayToString: {
+    kind: "externalDependency",
+    module: "@azure/core-util",
+    name: "uint8ArrayToString"
+  }
+};

--- a/packages/typespec-ts/src/contextManager.ts
+++ b/packages/typespec-ts/src/contextManager.ts
@@ -4,6 +4,7 @@ import { EmitContext } from "@typespec/compiler";
 import { SdkContext } from "@azure-tools/typespec-client-generator-core";
 import { SdkTypeContext } from "./framework/hooks/sdkTypes.js";
 import { Binder } from "./framework/hooks/binder.js";
+import { ExternalDependencies } from "./framework/dependency.js";
 
 /**
  * Contexts Object Guidelines
@@ -29,6 +30,7 @@ type Contexts = {
     tcgcContext: SdkContext;
   };
   binder: Binder;
+  dependencies: ExternalDependencies;
 };
 
 type ContextKey = keyof Contexts;

--- a/packages/typespec-ts/src/framework/dependency.ts
+++ b/packages/typespec-ts/src/framework/dependency.ts
@@ -1,0 +1,115 @@
+export interface ReferenceableSymbol {
+  kind: string;
+  name: string;
+  module: string;
+}
+
+export type ExternalDependencies = CoreDependencies &
+  Record<string, ReferenceableSymbol>;
+
+/**
+ * This interface defines the well known Core dependencies that plugins can use to override and provide their own implementations if needed
+ */
+export interface CoreDependencies extends Record<string, ReferenceableSymbol> {
+  Client: { kind: "externalDependency"; name: "Client"; module: string };
+  ClientOptions: {
+    kind: "externalDependency";
+    name: "ClientOptions";
+    module: string;
+  };
+  Pipeline: { kind: "externalDependency"; name: "Pipeline"; module: string };
+  getClient: { kind: "externalDependency"; name: "getClient"; module: string };
+  RestError: { kind: "externalDependency"; name: "RestError"; module: string };
+  OperationOptions: {
+    kind: "externalDependency";
+    name: "OperationOptions";
+    module: string;
+  };
+  PathUnckeckedResponse: {
+    kind: "externalDependency";
+    name: "PathUnckeckedResponse";
+    module: string;
+  };
+  AbortSignalLike: {
+    kind: "externalDependency";
+    name: "AbortSignalLike";
+    module: string;
+  };
+  createRestError: {
+    kind: "externalDependency";
+    name: "createRestError";
+    module: string;
+  };
+  operationOptionsToRequestParameters: {
+    kind: "externalDependency";
+    name: "operationOptionsToRequestParameters";
+    module: string;
+  };
+  uint8ArrayToString: {
+    kind: "externalDependency";
+    name: "uint8ArrayToString";
+    module: string;
+  };
+}
+
+const _CoreDependencies: CoreDependencies = {
+  Client: {
+    kind: "externalDependency",
+    name: "Client",
+    module: "@typespec/ts-http-runtime"
+  },
+  ClientOptions: {
+    kind: "externalDependency",
+    name: "ClientOptions",
+    module: "@typespec/ts-http-runtime"
+  },
+  Pipeline: {
+    kind: "externalDependency",
+    name: "Pipeline",
+    module: "@typespec/ts-http-runtime"
+  },
+  getClient: {
+    kind: "externalDependency",
+    name: "getClient",
+    module: "@typespec/ts-http-runtime"
+  },
+  RestError: {
+    kind: "externalDependency",
+    name: "RestError",
+    module: "@typespec/ts-http-runtime"
+  },
+  OperationOptions: {
+    kind: "externalDependency",
+    name: "OperationOptions",
+    module: "@typespec/ts-http-runtime"
+  },
+  PathUnckeckedResponse: {
+    kind: "externalDependency",
+    name: "PathUnckeckedResponse",
+    module: "@typespec/ts-http-runtime"
+  },
+  AbortSignalLike: {
+    kind: "externalDependency",
+    name: "AbortSignalLike",
+    module: "@typespec/ts-http-runtime"
+  },
+  createRestError: {
+    kind: "externalDependency",
+    name: "createRestError",
+    module: "@typespec/ts-http-runtime"
+  },
+  operationOptionsToRequestParameters: {
+    kind: "externalDependency",
+    name: "operationOptionsToRequestParameters",
+    module: "@typespec/ts-http-runtime"
+  },
+  uint8ArrayToString: {
+    kind: "externalDependency",
+    name: "uint8ArrayToString",
+    module: "@typespec/ts-http-runtime"
+  }
+} as const;
+
+export const DEFAULT_DEPENDENCIES = _CoreDependencies;
+
+export type CoreDependency = keyof CoreDependencies;

--- a/packages/typespec-ts/src/framework/hooks/binder.ts
+++ b/packages/typespec-ts/src/framework/hooks/binder.ts
@@ -27,7 +27,7 @@ export interface Binder {
     sourceFile: SourceFile
   ): string;
   resolveReference(refkey: unknown): string;
-  applyImports(): void;
+  resolveAllReferences(): void;
 }
 
 class BinderImp implements Binder {
@@ -36,8 +36,8 @@ class BinderImp implements Binder {
   private symbolsBySourceFile = new Map<SourceFile, Set<string>>();
   private project: Project;
 
-  constructor(project?: Project) {
-    this.project = project ?? new Project();
+  constructor(project: Project) {
+    this.project = project;
   }
 
   trackDeclaration(
@@ -194,7 +194,7 @@ class BinderImp implements Binder {
   /**
    * Applies all tracked imports to their respective source files.
    */
-  applyImports(): void {
+  resolveAllReferences(): void {
     for (const file of this.project.getSourceFiles()) {
       for (const [declarationKey, declaration] of this.declarations) {
         const placeholderKey = this.serializePlaceholder(declarationKey);
@@ -220,7 +220,7 @@ class BinderImp implements Binder {
 }
 
 // Provide the binder context to be used globally
-export function provideBinder(project?: Project): void {
+export function provideBinder(project: Project): void {
   return provideContext("binder", new BinderImp(project));
 }
 

--- a/packages/typespec-ts/src/framework/hooks/binder.ts
+++ b/packages/typespec-ts/src/framework/hooks/binder.ts
@@ -297,9 +297,7 @@ function countPlaceholderOccurrences(
   sourceFile: SourceFile,
   placeholder: string
 ): number {
-  const fileText = sourceFile.getFullText();
-  const regex = new RegExp(escapeRegExp(placeholder), "g");
-  return fileText.match(regex)?.length ?? 0;
+  return sourceFile.getFullText().split(placeholder).length - 1;
 }
 
 /**
@@ -311,9 +309,6 @@ function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-const placeholderPattern = new RegExp(/<PLACEHOLDER:\w+>/);
-
 function hasAnyPlaceholders(sourceFile: SourceFile): boolean {
-  const content = sourceFile.getFullText();
-  return placeholderPattern.test(content);
+  return sourceFile.getFullText().includes(`<PLACEHOLDER:`);
 }

--- a/packages/typespec-ts/src/framework/hooks/binder.ts
+++ b/packages/typespec-ts/src/framework/hooks/binder.ts
@@ -6,11 +6,18 @@ import {
   Project
 } from "ts-morph";
 import { provideContext, useContext } from "../../contextManager.js";
+import { ReferenceableSymbol } from "../dependency.js";
+import { provideDependencies, useDependencies } from "./useDependencies.js";
+import { refkey } from "../refkey.js";
 
 export interface DeclarationInfo {
   name: string;
   sourceFile: SourceFile;
   alias?: string;
+}
+
+export interface BinderOptions {
+  dependencies?: Record<string, ReferenceableSymbol>;
 }
 
 export interface Binder {
@@ -35,9 +42,13 @@ class BinderImp implements Binder {
   private imports = new Map<SourceFile, ImportDeclarationStructure[]>();
   private symbolsBySourceFile = new Map<SourceFile, Set<string>>();
   private project: Project;
+  private dependencies: Record<string, ReferenceableSymbol>;
 
-  constructor(project: Project) {
+  constructor(project: Project, options: BinderOptions = {}) {
     this.project = project;
+
+    provideDependencies(options.dependencies);
+    this.dependencies = useDependencies();
   }
 
   trackDeclaration(
@@ -135,7 +146,7 @@ class BinderImp implements Binder {
    * @returns The serialized placeholder string.
    */
   private serializePlaceholder(refkey: unknown): string {
-    return `PLACEHOLDER:${String(refkey)}`;
+    return `"<PLACEHOLDER:${String(refkey)}>"`;
   }
 
   /**
@@ -147,27 +158,33 @@ class BinderImp implements Binder {
    */
   private addImport(
     fileWhereImportIsAdded: SourceFile,
-    fileWhereImportPointsTo: SourceFile,
+    fileWhereImportPointsTo: SourceFile | string,
     name: string
   ): ImportSpecifierStructure {
     const importAlias = this.generateLocallyUniqueImportName(
       name,
       fileWhereImportIsAdded
     );
-    const relativePath =
-      fileWhereImportIsAdded.getRelativePathAsModuleSpecifierTo(
-        fileWhereImportPointsTo
-      );
+    let moduleSpecifier = "";
+    if (typeof fileWhereImportPointsTo === "string") {
+      moduleSpecifier = fileWhereImportPointsTo;
+    } else {
+      moduleSpecifier =
+        fileWhereImportIsAdded.getRelativePathAsModuleSpecifierTo(
+          fileWhereImportPointsTo
+        );
+    }
+
     const importStructures = this.imports.get(fileWhereImportIsAdded) || [];
 
     let importStructure = importStructures.find(
-      (imp) => imp.moduleSpecifier === relativePath
+      (imp) => imp.moduleSpecifier === moduleSpecifier
     );
 
     if (!importStructure) {
       importStructure = {
         kind: StructureKind.ImportDeclaration,
-        moduleSpecifier: relativePath,
+        moduleSpecifier,
         namedImports: []
       };
       importStructures.push(importStructure);
@@ -196,19 +213,8 @@ class BinderImp implements Binder {
    */
   resolveAllReferences(): void {
     for (const file of this.project.getSourceFiles()) {
-      for (const [declarationKey, declaration] of this.declarations) {
-        const placeholderKey = this.serializePlaceholder(declarationKey);
-        let name = declaration.name;
-        if (file !== declaration.sourceFile) {
-          const importDec = this.addImport(
-            file,
-            declaration.sourceFile,
-            declaration.name
-          );
-          name = importDec.alias ?? declaration.name;
-        }
-        replacePlaceholder(file, placeholderKey, name);
-      }
+      this.resolveDeclarationReferences(file);
+      this.resolveDependencyReferences(file);
     }
 
     for (const [sourceFile, importStructures] of this.imports) {
@@ -217,11 +223,49 @@ class BinderImp implements Binder {
       }
     }
   }
+
+  private resolveDependencyReferences(file: SourceFile) {
+    if (!hasAnyPlaceholders(file)) {
+      return;
+    }
+    for (const dependency of Object.values(this.dependencies)) {
+      const placeholder = this.serializePlaceholder(refkey(dependency));
+      const { name, module } = dependency;
+      const occurences = countPlaceholderOccurrences(file, placeholder);
+      if (occurences > 0) {
+        const importDec = this.addImport(file, module, name);
+        const uniqueName = importDec.alias ?? name;
+        replacePlaceholder(file, placeholder, uniqueName);
+      }
+    }
+  }
+
+  private resolveDeclarationReferences(file: SourceFile) {
+    if (!hasAnyPlaceholders(file)) {
+      return;
+    }
+    for (const [declarationKey, declaration] of this.declarations) {
+      const placeholderKey = this.serializePlaceholder(declarationKey);
+      let name = declaration.name;
+      if (file !== declaration.sourceFile) {
+        const importDec = this.addImport(
+          file,
+          declaration.sourceFile,
+          declaration.name
+        );
+        name = importDec.alias ?? declaration.name;
+      }
+      replacePlaceholder(file, placeholderKey, name);
+    }
+  }
 }
 
 // Provide the binder context to be used globally
-export function provideBinder(project: Project): void {
-  return provideContext("binder", new BinderImp(project));
+export function provideBinder(
+  project: Project,
+  options: BinderOptions = {}
+): void {
+  return provideContext("binder", new BinderImp(project, options));
 }
 
 /**
@@ -249,6 +293,15 @@ function replacePlaceholder(
   sourceFile.replaceWithText(updatedText);
 }
 
+function countPlaceholderOccurrences(
+  sourceFile: SourceFile,
+  placeholder: string
+): number {
+  const fileText = sourceFile.getFullText();
+  const regex = new RegExp(escapeRegExp(placeholder), "g");
+  return fileText.match(regex)?.length ?? 0;
+}
+
 /**
  * Escapes special characters in a string to be used in a regular expression.
  * @param string - The input string.
@@ -256,4 +309,11 @@ function replacePlaceholder(
  */
 function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const placeholderPattern = new RegExp(/<PLACEHOLDER:\w+>/);
+
+function hasAnyPlaceholders(sourceFile: SourceFile): boolean {
+  const content = sourceFile.getFullText();
+  return placeholderPattern.test(content);
 }

--- a/packages/typespec-ts/src/framework/hooks/useDependencies.ts
+++ b/packages/typespec-ts/src/framework/hooks/useDependencies.ts
@@ -1,0 +1,17 @@
+import { provideContext, useContext } from "../../contextManager.js";
+import { DEFAULT_DEPENDENCIES, ExternalDependencies } from "../dependency.js";
+
+export function provideDependencies(
+  customDependencies: Partial<ExternalDependencies> = {}
+) {
+  const dependencies = {
+    ...DEFAULT_DEPENDENCIES,
+    ...customDependencies
+  } as ExternalDependencies;
+
+  provideContext("dependencies", dependencies);
+}
+
+export function useDependencies(): ExternalDependencies {
+  return useContext("dependencies");
+}

--- a/packages/typespec-ts/src/framework/reference.ts
+++ b/packages/typespec-ts/src/framework/reference.ts
@@ -1,9 +1,19 @@
 import { useBinder } from "./hooks/binder.js";
-import { refkey as getRefKey } from "./refkey.js";
+import { refkey as getRefkey } from "./refkey.js";
+import { ReferenceableSymbol } from "./dependency.js";
 
 export function resolveReference(refkey: unknown): string | undefined {
   const binder = useBinder();
-  const stringRefkey = typeof refkey === "string" ? refkey : getRefKey(refkey);
+
+  let key = refkey;
+  if (isReferenceableSymbol(key)) {
+    key = getRefkey(key);
+  }
+
+  const stringRefkey = typeof key === "string" ? key : getRefkey(key);
 
   return binder.resolveReference(stringRefkey);
+}
+function isReferenceableSymbol(obj: any): obj is ReferenceableSymbol {
+  return obj?.kind === "externalDependency";
 }

--- a/packages/typespec-ts/src/framework/sample.ts
+++ b/packages/typespec-ts/src/framework/sample.ts
@@ -67,7 +67,7 @@ sourceFile2.addStatements(`${functionReference}();`);
 sourceFile2.addStatements(`let obj: ${modelReference} = { id: 1 };`);
 
 // Apply imports to ensure correct references
-binder.applyImports();
+binder.resolveAllReferences();
 
 // Output the generated files
 console.log("// test.ts");

--- a/packages/typespec-ts/test-next/integration/hooks/binder.test.ts
+++ b/packages/typespec-ts/test-next/integration/hooks/binder.test.ts
@@ -15,526 +15,724 @@ import { addDeclaration } from "../../../src/framework/declaration.js";
 import { resolveReference } from "../../../src/framework/reference.js";
 import {
   assertGetFunctionDeclaration,
+  assertGetImportStatements,
   assertGetInterfaceDeclaration,
   assertGetInterfaceProperty,
   assertGetVariableDeclaration
 } from "../../utils/tsmorph-utils.js";
+import { useDependencies } from "../../../src/framework/hooks/useDependencies.js";
+import { ExternalDependencies } from "../../../src/framework/dependency.js";
 
 describe("Binder", () => {
   let project: Project;
   let binder: Binder;
+  let Dependencies: ExternalDependencies;
 
   beforeEach(() => {
     project = new Project();
     provideBinder(project);
     binder = useBinder();
+    Dependencies = useDependencies();
   });
 
-  it("should track declarations correctly", () => {
-    const sourceFile = project.createSourceFile("test1.ts", "", {
-      overwrite: true
-    });
-    const model = {
-      name: "TestModel",
-      properties: [{ name: "foo", type: "string" }]
-    };
-
-    const interfaceDeclaration: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: model.name,
-      properties: model.properties.map((p) => ({ name: p.name, type: p.type }))
-    };
-
-    addDeclaration(sourceFile, interfaceDeclaration, model);
-    binder.resolveAllReferences();
-
-    assertGetInterfaceDeclaration(sourceFile, "TestModel");
-
-    console.log("// test1.ts");
-    console.log(sourceFile.getFullText());
-    // test1.ts
-    // interface TestModel {
-    //   foo: string;
-    // }
-  });
-
-  it("should handle declaration name conflicts", () => {
-    const sourceFile = project.createSourceFile("test1.ts", "", {
-      overwrite: true
-    });
-    const model1 = {
-      name: "TestModel",
-      properties: [{ name: "foo", type: "string" }]
-    };
-    const model2 = {
-      name: "TestModel",
-      properties: [{ name: "bar", type: "number" }]
-    };
-
-    const interfaceDeclaration1: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: model1.name,
-      properties: model1.properties.map((p) => ({ name: p.name, type: p.type }))
-    };
-
-    const interfaceDeclaration2: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: model2.name,
-      properties: model2.properties.map((p) => ({ name: p.name, type: p.type }))
-    };
-
-    addDeclaration(sourceFile, interfaceDeclaration1, model1);
-    addDeclaration(sourceFile, interfaceDeclaration2, model2);
-    binder.resolveAllReferences();
-
-    assertGetInterfaceDeclaration(sourceFile, "TestModel");
-    assertGetInterfaceDeclaration(sourceFile, "TestModel_1");
-
-    console.log("// test1.ts");
-    console.log(sourceFile.getFullText());
-
-    // test1.ts
-    // interface TestModel {
-    //   foo: string;
-    // }
-
-    // interface TestModel_1 {
-    //   bar: number;
-    // }
-  });
-
-  it("should defer references to declarations that don't exist", () => {
-    const sourceFile = project.createSourceFile("test1.ts", "", {
-      overwrite: true
-    });
-    const modelA = {
-      name: "TestModelA",
-      properties: [{ name: "foo", type: "string" }]
-    };
-    const modelB = {
-      name: "TestModelB",
-      properties: [{ name: "foo", type: modelA }]
-    };
-
-    const interfaceDeclarationA: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: modelA.name,
-      properties: modelA.properties.map((p) => ({ name: p.name, type: p.type }))
-    };
-
-    const interfaceDeclarationB: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: modelB.name,
-      properties: modelB.properties.map((p) => ({
-        name: p.name,
-        type: resolveReference(p.type)
-      }))
-    };
-
-    addDeclaration(sourceFile, interfaceDeclarationA, modelA);
-    addDeclaration(sourceFile, interfaceDeclarationB, modelB);
-    binder.resolveAllReferences();
-
-    assertGetInterfaceDeclaration(sourceFile, "TestModelA");
-    const modelBInterface = assertGetInterfaceDeclaration(
-      sourceFile,
-      "TestModelB"
-    );
-
-    const fooProp = assertGetInterfaceProperty(modelBInterface, "foo");
-
-    assert.equal(fooProp.getText(), "foo: TestModelA;");
-
-    console.log("// test1.ts");
-    console.log(sourceFile.getFullText());
-    // test1.ts
-    // interface TestModelA {
-    //   foo: string;
-    // }
-
-    // interface TestModelB {
-    //   foo: TestModelA;
-    // }
-  });
-
-  it("should handle import conflicts", () => {
-    const sourceFile1 = project.createSourceFile("test1.ts", "", {
-      overwrite: true
-    });
-    const sourceFile2 = project.createSourceFile("test2.ts", "", {
-      overwrite: true
-    });
-    const sourceFile3 = project.createSourceFile("test3.ts", "", {
-      overwrite: true
+  describe("External Dependencies Override", () => {
+    beforeEach(() => {
+      const customDependencies = {
+        ClientOptions: {
+          kind: "externalDependency",
+          name: "ClientOptions",
+          module: "@azure-rest/core-client"
+        }
+      };
+      provideBinder(project, { dependencies: customDependencies });
+      binder = useBinder();
+      Dependencies = useDependencies();
     });
 
-    const model1 = {
-      name: "TestModel",
-      properties: [{ name: "foo", type: "string" }]
-    };
-    const model2 = {
-      name: "TestModelB",
-      properties: [{ name: "bar", type: model1 }]
-    };
-    const model3 = {
-      name: "LastModel",
-      properties: [
-        { name: "baz", type: model1 },
-        { name: "qux", type: model2 }
-      ]
-    };
+    it("should track declarations and dependencies correctly", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const model = {
+        name: "Client",
+        properties: [
+          { name: "foo", type: resolveReference(Dependencies.Client) },
+          {
+            name: "bar",
+            type: resolveReference(Dependencies.ClientOptions)
+          }
+        ]
+      };
 
-    const interfaceDeclaration1: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: model1.name,
-      properties: model1.properties.map((p) => ({ name: p.name, type: p.type }))
-    };
+      const interfaceDeclaration: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model.name,
+        properties: model.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
 
-    const interfaceDeclaration2: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: model2.name,
-      properties: model2.properties.map((p) => ({
-        name: p.name,
-        type: resolveReference(p.type)
-      }))
-    };
+      addDeclaration(sourceFile, interfaceDeclaration, model);
+      binder.resolveAllReferences();
 
-    const interfaceDeclaration3: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: model3.name,
-      properties: model3.properties.map((p) => ({
-        name: p.name,
-        type: resolveReference(p.type)
-      }))
-    };
-
-    addDeclaration(sourceFile1, interfaceDeclaration1, model1);
-    addDeclaration(sourceFile2, interfaceDeclaration2, model2);
-    addDeclaration(sourceFile3, interfaceDeclaration3, model3);
-
-    binder.resolveAllReferences();
-
-    const lasModelInterface = assertGetInterfaceDeclaration(
-      sourceFile3,
-      "LastModel"
-    );
-
-    const bazProp = assertGetInterfaceProperty(lasModelInterface, "baz");
-    const quxProp = assertGetInterfaceProperty(lasModelInterface, "qux");
-
-    expect(bazProp?.getType().getText()).toBe("TestModel");
-    expect(quxProp?.getType().getText()).toBe("TestModelB");
-
-    const imports = sourceFile3
-      .getImportDeclarations()
-      .flatMap((i) =>
-        i
-          .getNamedImports()
-          .map((n) => n.getAliasNode()?.getText() ?? n.getName())
+      const ifaceDeclaration = assertGetInterfaceDeclaration(
+        sourceFile,
+        "Client"
       );
-    expect(imports).toEqual(["TestModel", "TestModelB"]);
+      const fooProperty = assertGetInterfaceProperty(ifaceDeclaration, "foo");
+      const barProperty = assertGetInterfaceProperty(ifaceDeclaration, "bar");
 
-    console.log("// test1.ts");
-    console.log(sourceFile1.getFullText());
-    console.log("// test2.ts");
-    console.log(sourceFile2.getFullText());
-    console.log("// test3.ts");
-    console.log(sourceFile3.getFullText());
-    // test1.ts
-    // interface TestModel {
-    //   foo: string;
-    // }
+      expect(fooProperty.getText()).toBe("foo: Client_1;");
+      expect(barProperty.getText()).toBe("bar: ClientOptions;");
 
-    // // test2.ts
-    // import { TestModel } from "./test1";
+      const customImport = assertGetImportStatements(
+        sourceFile,
+        "@azure-rest/core-client"
+      );
+      const defaultImport = assertGetImportStatements(
+        sourceFile,
+        "@typespec/ts-http-runtime"
+      );
 
-    // interface TestModelB {
-    //   bar: TestModel;
-    // }
+      expect(customImport.getNamedImports()[0].getName()).equal(
+        "ClientOptions"
+      );
 
-    // // test3.ts
-    // import { TestModel } from "./test1";
-    // import { TestModelB } from "./test2";
+      expect(defaultImport.getNamedImports()[0].getName()).equal("Client");
 
-    // interface LastModel {
-    //   baz: TestModel;
-    //   qux: TestModelB;
-    // }
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+      // test1.ts
+      // interface Client {
+      //   foo: Client_1;
+      // }
+    });
   });
 
-  it("should handle non-interface types as well", () => {
-    const sourceFile1 = project.createSourceFile("test1.ts", "", {
-      overwrite: true
+  describe("External Dependencies", () => {
+    it("should track declarations and dependencies correctly", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const model = {
+        name: "Client",
+        properties: [
+          { name: "foo", type: resolveReference(Dependencies.Client) },
+          {
+            name: "bar",
+            type: resolveReference(Dependencies.ClientOptions)
+          }
+        ]
+      };
+
+      const interfaceDeclaration: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model.name,
+        properties: model.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
+
+      addDeclaration(sourceFile, interfaceDeclaration, model);
+      binder.resolveAllReferences();
+
+      const ifaceDeclaration = assertGetInterfaceDeclaration(
+        sourceFile,
+        "Client"
+      );
+      const fooProperty = assertGetInterfaceProperty(ifaceDeclaration, "foo");
+      const barProperty = assertGetInterfaceProperty(ifaceDeclaration, "bar");
+
+      expect(fooProperty.getText()).toBe("foo: Client_1;");
+      expect(barProperty.getText()).toBe("bar: ClientOptions;");
+
+      const defaultImport = assertGetImportStatements(
+        sourceFile,
+        "@typespec/ts-http-runtime"
+      );
+
+      expect(
+        defaultImport
+          .getNamedImports()
+          .map((i) => i.getAliasNode()?.getText() ?? i.getName())
+      ).to.deep.equal(["Client_1", "ClientOptions"]);
+
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+      // test1.ts
+      // interface Client {
+      //   foo: Client_1;
+      // }
     });
 
-    const fnObject = {
-      name: "testFn",
-      returnType: "string",
-      body: `console.log("hello world!");`
-    };
+    it("should handle name collision with external dependency", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const model = {
+        name: "TestModel",
+        properties: [{ name: "foo", type: "string" }]
+      };
 
-    const funDeclaration: FunctionDeclarationStructure = {
-      kind: StructureKind.Function,
-      name: fnObject.name,
-      returnType: fnObject.returnType,
-      statements: fnObject.body
-    };
+      const interfaceDeclaration: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model.name,
+        properties: model.properties.map((p) => ({
+          name: p.name,
+          type: resolveReference(Dependencies.Client)
+        }))
+      };
 
-    addDeclaration(sourceFile1, funDeclaration, fnObject);
+      addDeclaration(sourceFile, interfaceDeclaration, model);
+      binder.resolveAllReferences();
 
-    const sourceFile2 = project.createSourceFile("test2.ts", "", {
-      overwrite: true
+      const ifaceDeclaration = assertGetInterfaceDeclaration(
+        sourceFile,
+        "TestModel"
+      );
+      const fooProperty = assertGetInterfaceProperty(ifaceDeclaration, "foo");
+
+      expect(fooProperty.getText()).toBe("foo: Client;");
+
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+      // test1.ts
+      // interface TestModel {
+      //   foo: Client;
+      // }
     });
-    sourceFile2.addStatements(`${resolveReference(fnObject)}();`);
-
-    const binder = useBinder();
-    binder.resolveAllReferences();
-
-    console.log("// test1.ts");
-    console.log(sourceFile1.getFullText());
-    console.log("// test2.ts");
-    console.log(sourceFile2.getFullText());
-    // test1.ts
-    // function testFn(): string {
-    //   console.log("hello world!");
-    // }
-    //
-    // // test2.ts
-    // import { testFn } from "./test1";
-    //
-    // testFn();
   });
 
-  it("should track and resolve multiple types of declarations", () => {
-    const sourceFile = project.createSourceFile("test1.ts", "", {
-      overwrite: true
-    });
-    const model = {
-      name: "TestModel",
-      properties: [{ name: "foo", type: "string" }]
-    };
-    const functionModel = {
-      name: "TestFunction",
-      returnType: "void",
-      body: `console.log("Hello World");`
-    };
+  describe("Declarations", () => {
+    it("should track declarations correctly", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const model = {
+        name: "TestModel",
+        properties: [{ name: "foo", type: "string" }]
+      };
 
-    const interfaceDeclaration: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: model.name,
-      properties: model.properties.map((p) => ({ name: p.name, type: p.type }))
-    };
+      const interfaceDeclaration: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model.name,
+        properties: model.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
 
-    const functionDeclaration: FunctionDeclarationStructure = {
-      kind: StructureKind.Function,
-      name: functionModel.name,
-      returnType: functionModel.returnType,
-      statements: functionModel.body
-    };
+      addDeclaration(sourceFile, interfaceDeclaration, model);
+      binder.resolveAllReferences();
 
-    addDeclaration(sourceFile, interfaceDeclaration, model);
-    addDeclaration(sourceFile, functionDeclaration, functionModel);
+      assertGetInterfaceDeclaration(sourceFile, "TestModel");
 
-    binder.resolveAllReferences();
-
-    assertGetInterfaceDeclaration(sourceFile, "TestModel");
-    assertGetFunctionDeclaration(sourceFile, "TestFunction");
-    console.log("// test1.ts");
-    console.log(sourceFile.getFullText());
-
-    // test1.ts
-    // interface TestModel {
-    //   foo: string;
-    // }
-
-    // function TestFunction(): void {
-    //   console.log("Hello World");
-    // }
-  });
-
-  it("should handle cyclic references", () => {
-    const sourceFile = project.createSourceFile("test1.ts", "", {
-      overwrite: true
-    });
-    const modelA = {
-      name: "ModelA",
-      properties: [{ name: "propA", type: "ModelB" }]
-    };
-    const modelB = {
-      name: "ModelB",
-      properties: [{ name: "propB", type: "ModelA" }]
-    };
-
-    const interfaceDeclarationA: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: modelA.name,
-      properties: modelA.properties.map((p) => ({
-        name: p.name,
-        type: resolveReference(modelB)
-      }))
-    };
-
-    const interfaceDeclarationB: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: modelB.name,
-      properties: modelB.properties.map((p) => ({
-        name: p.name,
-        type: resolveReference(modelA)
-      }))
-    };
-
-    addDeclaration(sourceFile, interfaceDeclarationA, modelA);
-    addDeclaration(sourceFile, interfaceDeclarationB, modelB);
-
-    const binder = useBinder();
-    binder.resolveAllReferences();
-
-    const propA = sourceFile.getInterface("ModelA")?.getProperty("propA");
-    const propB = sourceFile.getInterface("ModelB")?.getProperty("propB");
-
-    expect(propA?.getType().getText()).toBe("ModelB");
-    expect(propB?.getType().getText()).toBe("ModelA");
-
-    console.log("// test1.ts");
-    console.log(sourceFile.getFullText());
-    // test1.ts
-    // interface ModelA {
-    //   propA: ModelB;
-    // }
-    //
-    // interface ModelB {
-    //   propB: ModelA;
-    // }
-  });
-
-  it("should handle mixed type declarations and references", () => {
-    const sourceFile = project.createSourceFile("test1.ts", "", {
-      overwrite: true
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+      // test1.ts
+      // interface TestModel {
+      //   foo: string;
+      // }
     });
 
-    const interfaceModel = {
-      name: "MyInterface",
-      properties: [{ name: "id", type: "number" }]
-    };
-    const functionModel = {
-      name: "MyFunction",
-      returnType: "void",
-      body: `console.log("Hello World");`
-    };
+    it("should handle declaration name conflicts", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const model1 = {
+        name: "TestModel",
+        properties: [{ name: "foo", type: "string" }]
+      };
+      const model2 = {
+        name: "TestModel",
+        properties: [{ name: "bar", type: "number" }]
+      };
 
-    const interfaceDeclaration: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: interfaceModel.name,
-      properties: interfaceModel.properties.map((p) => ({
-        name: p.name,
-        type: p.type
-      }))
-    };
+      const interfaceDeclaration1: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model1.name,
+        properties: model1.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
 
-    const functionDeclaration: FunctionDeclarationStructure = {
-      kind: StructureKind.Function,
-      name: functionModel.name,
-      returnType: functionModel.returnType,
-      statements: functionModel.body
-    };
+      const interfaceDeclaration2: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model2.name,
+        properties: model2.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
 
-    addDeclaration(sourceFile, interfaceDeclaration, interfaceModel);
-    addDeclaration(sourceFile, functionDeclaration, functionModel);
+      addDeclaration(sourceFile, interfaceDeclaration1, model1);
+      addDeclaration(sourceFile, interfaceDeclaration2, model2);
+      binder.resolveAllReferences();
 
-    const sourceFile2 = project.createSourceFile("test2.ts", "", {
-      overwrite: true
+      assertGetInterfaceDeclaration(sourceFile, "TestModel");
+      assertGetInterfaceDeclaration(sourceFile, "TestModel_1");
+
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+
+      // test1.ts
+      // interface TestModel {
+      //   foo: string;
+      // }
+
+      // interface TestModel_1 {
+      //   bar: number;
+      // }
     });
-    sourceFile2.addStatements(`${resolveReference(functionModel)}();`);
-    sourceFile2.addStatements(
-      `let obj: ${resolveReference(interfaceModel)} = { id: 1 };`
-    );
 
-    const binder = useBinder();
-    binder.resolveAllReferences();
+    it("should defer references to declarations that don't exist", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const modelA = {
+        name: "TestModelA",
+        properties: [{ name: "foo", type: "string" }]
+      };
+      const modelB = {
+        name: "TestModelB",
+        properties: [{ name: "foo", type: modelA }]
+      };
 
-    const variableDeclaration = assertGetVariableDeclaration(
-      sourceFile2,
-      "obj"
-    );
-    assert.equal(
-      variableDeclaration.getText(),
-      "let obj: MyInterface = { id: 1 };"
-    );
+      const interfaceDeclarationA: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: modelA.name,
+        properties: modelA.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
 
-    console.log("// test1.ts");
-    console.log(sourceFile.getFullText());
-    console.log("// test2.ts");
-    console.log(sourceFile2.getFullText());
-    // test1.ts
-    // interface MyInterface {
-    //   id: number;
-    // }
+      const interfaceDeclarationB: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: modelB.name,
+        properties: modelB.properties.map((p) => ({
+          name: p.name,
+          type: resolveReference(p.type)
+        }))
+      };
 
-    // function MyFunction(): void {
-    //   console.log("Hello World");
-    // }
+      addDeclaration(sourceFile, interfaceDeclarationA, modelA);
+      addDeclaration(sourceFile, interfaceDeclarationB, modelB);
+      binder.resolveAllReferences();
 
-    // // test2.ts
-    // import { MyFunction, MyInterface } from "./test1";
+      assertGetInterfaceDeclaration(sourceFile, "TestModelA");
+      const modelBInterface = assertGetInterfaceDeclaration(
+        sourceFile,
+        "TestModelB"
+      );
 
-    // MyFunction();
-    // let obj: MyInterface = { id: 1 };
-  });
+      const fooProp = assertGetInterfaceProperty(modelBInterface, "foo");
 
-  it("should defer references to declarations that don't exist", () => {
-    const sourceFile = project.createSourceFile("test1.ts", "", {
-      overwrite: true
+      assert.equal(fooProp.getText(), "foo: TestModelA;");
+
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+      // test1.ts
+      // interface TestModelA {
+      //   foo: string;
+      // }
+
+      // interface TestModelB {
+      //   foo: TestModelA;
+      // }
     });
-    const model = {
-      name: "TestModel",
-      properties: [{ name: "foo", type: "string" }]
-    };
 
-    const modelB = {
-      name: "TestModelB",
-      properties: [{ name: "foo", type: model }]
-    };
+    it("should handle import conflicts", () => {
+      const sourceFile1 = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const sourceFile2 = project.createSourceFile("test2.ts", "", {
+        overwrite: true
+      });
+      const sourceFile3 = project.createSourceFile("test3.ts", "", {
+        overwrite: true
+      });
 
-    const interfaceDeclaration: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: model.name,
-      properties: model.properties.map((p) => ({ name: p.name, type: p.type }))
-    };
+      const model1 = {
+        name: "TestModel",
+        properties: [{ name: "foo", type: "string" }]
+      };
+      const model2 = {
+        name: "TestModelB",
+        properties: [{ name: "bar", type: model1 }]
+      };
+      const model3 = {
+        name: "LastModel",
+        properties: [
+          { name: "baz", type: model1 },
+          { name: "qux", type: model2 }
+        ]
+      };
 
-    const interfaceDeclarationB: InterfaceDeclarationStructure = {
-      kind: StructureKind.Interface,
-      name: modelB.name,
-      properties: modelB.properties.map((p) => ({
-        name: p.name,
-        type: resolveReference(p.type)
-      }))
-    };
+      const interfaceDeclaration1: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model1.name,
+        properties: model1.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
 
-    addDeclaration(sourceFile, interfaceDeclaration, model);
-    addDeclaration(sourceFile, interfaceDeclarationB, modelB);
+      const interfaceDeclaration2: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model2.name,
+        properties: model2.properties.map((p) => ({
+          name: p.name,
+          type: resolveReference(p.type)
+        }))
+      };
 
-    const binder = useBinder();
-    binder.resolveAllReferences();
+      const interfaceDeclaration3: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model3.name,
+        properties: model3.properties.map((p) => ({
+          name: p.name,
+          type: resolveReference(p.type)
+        }))
+      };
 
-    assertGetInterfaceDeclaration(sourceFile, "TestModel");
-    const modelBInterface = assertGetInterfaceDeclaration(
-      sourceFile,
-      "TestModelB"
-    );
+      addDeclaration(sourceFile1, interfaceDeclaration1, model1);
+      addDeclaration(sourceFile2, interfaceDeclaration2, model2);
+      addDeclaration(sourceFile3, interfaceDeclaration3, model3);
 
-    const fooProp = assertGetInterfaceProperty(modelBInterface, "foo");
+      binder.resolveAllReferences();
 
-    assert.equal(fooProp.getText(), "foo: TestModel;");
+      const lasModelInterface = assertGetInterfaceDeclaration(
+        sourceFile3,
+        "LastModel"
+      );
 
-    console.log("// test1.ts");
-    console.log(sourceFile.getFullText());
-    // test1.ts
-    // interface TestModel {
-    //   foo: string;
-    // }
+      const bazProp = assertGetInterfaceProperty(lasModelInterface, "baz");
+      const quxProp = assertGetInterfaceProperty(lasModelInterface, "qux");
 
-    // interface TestModelB {
-    //   foo: TestModel;
-    // }
+      expect(bazProp?.getType().getText()).toBe("TestModel");
+      expect(quxProp?.getType().getText()).toBe("TestModelB");
+
+      const imports = sourceFile3
+        .getImportDeclarations()
+        .flatMap((i) =>
+          i
+            .getNamedImports()
+            .map((n) => n.getAliasNode()?.getText() ?? n.getName())
+        );
+      expect(imports).toEqual(["TestModel", "TestModelB"]);
+
+      console.log("// test1.ts");
+      console.log(sourceFile1.getFullText());
+      console.log("// test2.ts");
+      console.log(sourceFile2.getFullText());
+      console.log("// test3.ts");
+      console.log(sourceFile3.getFullText());
+      // test1.ts
+      // interface TestModel {
+      //   foo: string;
+      // }
+
+      // // test2.ts
+      // import { TestModel } from "./test1";
+
+      // interface TestModelB {
+      //   bar: TestModel;
+      // }
+
+      // // test3.ts
+      // import { TestModel } from "./test1";
+      // import { TestModelB } from "./test2";
+
+      // interface LastModel {
+      //   baz: TestModel;
+      //   qux: TestModelB;
+      // }
+    });
+
+    it("should handle non-interface types as well", () => {
+      const sourceFile1 = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+
+      const fnObject = {
+        name: "testFn",
+        returnType: "string",
+        body: `console.log("hello world!");`
+      };
+
+      const funDeclaration: FunctionDeclarationStructure = {
+        kind: StructureKind.Function,
+        name: fnObject.name,
+        returnType: fnObject.returnType,
+        statements: fnObject.body
+      };
+
+      addDeclaration(sourceFile1, funDeclaration, fnObject);
+
+      const sourceFile2 = project.createSourceFile("test2.ts", "", {
+        overwrite: true
+      });
+      sourceFile2.addStatements(`${resolveReference(fnObject)}();`);
+
+      const binder = useBinder();
+      binder.resolveAllReferences();
+
+      console.log("// test1.ts");
+      console.log(sourceFile1.getFullText());
+      console.log("// test2.ts");
+      console.log(sourceFile2.getFullText());
+      // test1.ts
+      // function testFn(): string {
+      //   console.log("hello world!");
+      // }
+      //
+      // // test2.ts
+      // import { testFn } from "./test1";
+      //
+      // testFn();
+    });
+
+    it("should track and resolve multiple types of declarations", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const model = {
+        name: "TestModel",
+        properties: [{ name: "foo", type: "string" }]
+      };
+      const functionModel = {
+        name: "TestFunction",
+        returnType: "void",
+        body: `console.log("Hello World");`
+      };
+
+      const interfaceDeclaration: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model.name,
+        properties: model.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
+
+      const functionDeclaration: FunctionDeclarationStructure = {
+        kind: StructureKind.Function,
+        name: functionModel.name,
+        returnType: functionModel.returnType,
+        statements: functionModel.body
+      };
+
+      addDeclaration(sourceFile, interfaceDeclaration, model);
+      addDeclaration(sourceFile, functionDeclaration, functionModel);
+
+      binder.resolveAllReferences();
+
+      assertGetInterfaceDeclaration(sourceFile, "TestModel");
+      assertGetFunctionDeclaration(sourceFile, "TestFunction");
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+
+      // test1.ts
+      // interface TestModel {
+      //   foo: string;
+      // }
+
+      // function TestFunction(): void {
+      //   console.log("Hello World");
+      // }
+    });
+
+    it("should handle cyclic references", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const modelA = {
+        name: "ModelA",
+        properties: [{ name: "propA", type: "ModelB" }]
+      };
+      const modelB = {
+        name: "ModelB",
+        properties: [{ name: "propB", type: "ModelA" }]
+      };
+
+      const interfaceDeclarationA: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: modelA.name,
+        properties: modelA.properties.map((p) => ({
+          name: p.name,
+          type: resolveReference(modelB)
+        }))
+      };
+
+      const interfaceDeclarationB: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: modelB.name,
+        properties: modelB.properties.map((p) => ({
+          name: p.name,
+          type: resolveReference(modelA)
+        }))
+      };
+
+      addDeclaration(sourceFile, interfaceDeclarationA, modelA);
+      addDeclaration(sourceFile, interfaceDeclarationB, modelB);
+
+      const binder = useBinder();
+      binder.resolveAllReferences();
+
+      const propA = sourceFile.getInterface("ModelA")?.getProperty("propA");
+      const propB = sourceFile.getInterface("ModelB")?.getProperty("propB");
+
+      expect(propA?.getType().getText()).toBe("ModelB");
+      expect(propB?.getType().getText()).toBe("ModelA");
+
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+      // test1.ts
+      // interface ModelA {
+      //   propA: ModelB;
+      // }
+      //
+      // interface ModelB {
+      //   propB: ModelA;
+      // }
+    });
+
+    it("should handle mixed type declarations and references", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+
+      const interfaceModel = {
+        name: "MyInterface",
+        properties: [{ name: "id", type: "number" }]
+      };
+      const functionModel = {
+        name: "MyFunction",
+        returnType: "void",
+        body: `console.log("Hello World");`
+      };
+
+      const interfaceDeclaration: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: interfaceModel.name,
+        properties: interfaceModel.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
+
+      const functionDeclaration: FunctionDeclarationStructure = {
+        kind: StructureKind.Function,
+        name: functionModel.name,
+        returnType: functionModel.returnType,
+        statements: functionModel.body
+      };
+
+      addDeclaration(sourceFile, interfaceDeclaration, interfaceModel);
+      addDeclaration(sourceFile, functionDeclaration, functionModel);
+
+      const sourceFile2 = project.createSourceFile("test2.ts", "", {
+        overwrite: true
+      });
+      sourceFile2.addStatements(`${resolveReference(functionModel)}();`);
+      sourceFile2.addStatements(
+        `let obj: ${resolveReference(interfaceModel)} = { id: 1 };`
+      );
+
+      const binder = useBinder();
+      binder.resolveAllReferences();
+
+      const variableDeclaration = assertGetVariableDeclaration(
+        sourceFile2,
+        "obj"
+      );
+      assert.equal(
+        variableDeclaration.getText(),
+        "let obj: MyInterface = { id: 1 };"
+      );
+
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+      console.log("// test2.ts");
+      console.log(sourceFile2.getFullText());
+      // test1.ts
+      // interface MyInterface {
+      //   id: number;
+      // }
+
+      // function MyFunction(): void {
+      //   console.log("Hello World");
+      // }
+
+      // // test2.ts
+      // import { MyFunction, MyInterface } from "./test1";
+
+      // MyFunction();
+      // let obj: MyInterface = { id: 1 };
+    });
+
+    it("should defer references to declarations that don't exist", () => {
+      const sourceFile = project.createSourceFile("test1.ts", "", {
+        overwrite: true
+      });
+      const model = {
+        name: "TestModel",
+        properties: [{ name: "foo", type: "string" }]
+      };
+
+      const modelB = {
+        name: "TestModelB",
+        properties: [{ name: "foo", type: model }]
+      };
+
+      const interfaceDeclaration: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: model.name,
+        properties: model.properties.map((p) => ({
+          name: p.name,
+          type: p.type
+        }))
+      };
+
+      const interfaceDeclarationB: InterfaceDeclarationStructure = {
+        kind: StructureKind.Interface,
+        name: modelB.name,
+        properties: modelB.properties.map((p) => ({
+          name: p.name,
+          type: resolveReference(p.type)
+        }))
+      };
+
+      addDeclaration(sourceFile, interfaceDeclaration, model);
+      addDeclaration(sourceFile, interfaceDeclarationB, modelB);
+
+      const binder = useBinder();
+      binder.resolveAllReferences();
+
+      assertGetInterfaceDeclaration(sourceFile, "TestModel");
+      const modelBInterface = assertGetInterfaceDeclaration(
+        sourceFile,
+        "TestModelB"
+      );
+
+      const fooProp = assertGetInterfaceProperty(modelBInterface, "foo");
+
+      assert.equal(fooProp.getText(), "foo: TestModel;");
+
+      console.log("// test1.ts");
+      console.log(sourceFile.getFullText());
+      // test1.ts
+      // interface TestModel {
+      //   foo: string;
+      // }
+
+      // interface TestModelB {
+      //   foo: TestModel;
+      // }
+    });
   });
 });

--- a/packages/typespec-ts/test-next/integration/hooks/binder.test.ts
+++ b/packages/typespec-ts/test-next/integration/hooks/binder.test.ts
@@ -46,7 +46,7 @@ describe("Binder", () => {
     };
 
     addDeclaration(sourceFile, interfaceDeclaration, model);
-    binder.applyImports();
+    binder.resolveAllReferences();
 
     assertGetInterfaceDeclaration(sourceFile, "TestModel");
 
@@ -85,7 +85,7 @@ describe("Binder", () => {
 
     addDeclaration(sourceFile, interfaceDeclaration1, model1);
     addDeclaration(sourceFile, interfaceDeclaration2, model2);
-    binder.applyImports();
+    binder.resolveAllReferences();
 
     assertGetInterfaceDeclaration(sourceFile, "TestModel");
     assertGetInterfaceDeclaration(sourceFile, "TestModel_1");
@@ -133,7 +133,7 @@ describe("Binder", () => {
 
     addDeclaration(sourceFile, interfaceDeclarationA, modelA);
     addDeclaration(sourceFile, interfaceDeclarationB, modelB);
-    binder.applyImports();
+    binder.resolveAllReferences();
 
     assertGetInterfaceDeclaration(sourceFile, "TestModelA");
     const modelBInterface = assertGetInterfaceDeclaration(
@@ -212,7 +212,7 @@ describe("Binder", () => {
     addDeclaration(sourceFile2, interfaceDeclaration2, model2);
     addDeclaration(sourceFile3, interfaceDeclaration3, model3);
 
-    binder.applyImports();
+    binder.resolveAllReferences();
 
     const lasModelInterface = assertGetInterfaceDeclaration(
       sourceFile3,
@@ -288,7 +288,7 @@ describe("Binder", () => {
     sourceFile2.addStatements(`${resolveReference(fnObject)}();`);
 
     const binder = useBinder();
-    binder.applyImports();
+    binder.resolveAllReferences();
 
     console.log("// test1.ts");
     console.log(sourceFile1.getFullText());
@@ -335,7 +335,7 @@ describe("Binder", () => {
     addDeclaration(sourceFile, interfaceDeclaration, model);
     addDeclaration(sourceFile, functionDeclaration, functionModel);
 
-    binder.applyImports();
+    binder.resolveAllReferences();
 
     assertGetInterfaceDeclaration(sourceFile, "TestModel");
     assertGetFunctionDeclaration(sourceFile, "TestFunction");
@@ -387,7 +387,7 @@ describe("Binder", () => {
     addDeclaration(sourceFile, interfaceDeclarationB, modelB);
 
     const binder = useBinder();
-    binder.applyImports();
+    binder.resolveAllReferences();
 
     const propA = sourceFile.getInterface("ModelA")?.getProperty("propA");
     const propB = sourceFile.getInterface("ModelB")?.getProperty("propB");
@@ -450,7 +450,7 @@ describe("Binder", () => {
     );
 
     const binder = useBinder();
-    binder.applyImports();
+    binder.resolveAllReferences();
 
     const variableDeclaration = assertGetVariableDeclaration(
       sourceFile2,
@@ -514,7 +514,7 @@ describe("Binder", () => {
     addDeclaration(sourceFile, interfaceDeclarationB, modelB);
 
     const binder = useBinder();
-    binder.applyImports();
+    binder.resolveAllReferences();
 
     assertGetInterfaceDeclaration(sourceFile, "TestModel");
     const modelBInterface = assertGetInterfaceDeclaration(

--- a/packages/typespec-ts/test-next/utils/tsmorph-utils.ts
+++ b/packages/typespec-ts/test-next/utils/tsmorph-utils.ts
@@ -28,6 +28,18 @@ export function assertGetInterfaceProperty(
   return property;
 }
 
+export function assertGetImportStatements(
+  sourceFile: SourceFile,
+  moduleName: string
+) {
+  const importStatements = sourceFile.getImportDeclarations();
+  const importStatement = importStatements.find((importStatement) =>
+    importStatement.getModuleSpecifierValue().includes(moduleName)
+  );
+  assert(importStatement, `Import statement for ${moduleName} not found`);
+  return importStatement;
+}
+
 export function assertGetVariableDeclaration(
   sourceFile: SourceFile,
   name: string


### PR DESCRIPTION
# Binder - Support External Dependencies

Whit this change the binder supports:
 * Referencing symbols from external dependencies
 * There is a default set of dependencies that point to `@typespec/ts-http-runtime`
 * Users can override these by providing a custom record with imports if they need to import from a different package.

## Sample
**Referencing an external dependency (ClientOptions)**
```ts
import { Project } from "ts-morph"
import {provideBinder} from "../framework/binder.js";
import { addDeclaration } from "../framework/declaration.js";
import { resolveReference } from "../framework/reference.js";

const project = new Project();
provideBinder(project);
const binder = useBinder();
const Dependencies = useDependencies();


const sourceFile = project.createSourceFile("test1.ts", "", {
   overwrite: true
});

const interfaceDeclaration: InterfaceDeclarationStructure = {
        kind: StructureKind.Interface,
        name: "Foo",
        properties: [{
          name: "options",
          type: resolveReference(Dependencies.ClientOptions)
        }]
};

addDeclaration(sourceFile, interfaceDeclaration, "Foo");
binder.resolveAllReferences();

console.log(sourceFile.getFullText())

// test1.ts
//
// import { OperationOptions } from "@typespec/ts-http-runtime";
//
// interface Foo {
//    options: OperationOptions
// }
 ```
