### PR TITLE
Fix invalid versioning in client.tsp

### DIFF
--- a/packages/typespec-test/test/loadtesting_modular/spec/client.tsp
+++ b/packages/typespec-test/test/loadtesting_modular/spec/client.tsp
@@ -5,8 +5,6 @@ using TypeSpec.Versioning;
 using Azure.ClientGenerator.Core;
 using Microsoft.LoadTestService;
 
-@useDependency(APIVersions.v2022_11_01)
-@useDependency(APIVersions.v2023_04_01_preview)
 @useDependency(APIVersions.v2024_05_01_preview)
 namespace Customizations;
 


### PR DESCRIPTION
Update with https://github.com/Azure/azure-rest-api-specs/pull/30005

Fix https://dev.azure.com/azure-sdk/public/_build/results?buildId=3993520&view=logs&j=830f3c89-f0a6-536d-4907-0d5f5b592ed8&t=df42c93f-8bab-5640-0499-96898203e019&l=33