### PR TITLE
use-record-of-any-for-additional-properties-in-modular

### DIFF
--- a/packages/rlc-common/src/interfaces.ts
+++ b/packages/rlc-common/src/interfaces.ts
@@ -244,7 +244,6 @@ export interface RLCOptions {
   flavor?: PackageFlavor;
   enableModelNamespace?: boolean;
   hierarchyClient?: boolean;
-  compatibilityMode?: boolean;
   experimentalExtensibleEnums?: boolean;
 }
 

--- a/packages/typespec-ts/src/lib.ts
+++ b/packages/typespec-ts/src/lib.ts
@@ -11,7 +11,6 @@ import { Options } from "prettier";
 
 export interface EmitterOptions extends RLCOptions {
   branded?: boolean;
-  compatibilityMode?: boolean;
   experimentalExtensibleEnums?: boolean;
 }
 
@@ -91,7 +90,6 @@ export const RLCOptionsSchema: JSONSchemaType<EmitterOptions> = {
       enum: ["esm", "cjs"],
       default: "esm"
     },
-    compatibilityMode: { type: "boolean", nullable: true },
     experimentalExtensibleEnums: { type: "boolean", nullable: true }
   },
   required: []
@@ -224,12 +222,6 @@ const libDef = {
       severity: "warning",
       messages: {
         default: paramMessage`Please note the header ${"type"} is not serializable.`
-      }
-    },
-    "compatible-additional-properties": {
-      severity: "warning",
-      messages: {
-        default: paramMessage`Please note that only compatible additional properties is supported for now. You can enable compatibilityMode to generate compatible additional properties for the model - ${"modelName"}.`
       }
     },
     "default-response-body-type": {

--- a/packages/typespec-ts/src/modular/buildCodeModel.ts
+++ b/packages/typespec-ts/src/modular/buildCodeModel.ts
@@ -98,7 +98,6 @@ import {
   parseItemName,
   parseNextLinkName
 } from "../utils/operationUtil.js";
-import { isModelWithAdditionalProperties } from "./emitModels.js";
 import { getType as getTypeName } from "./helpers/typeHelpers.js";
 import {
   Client as HrlcClient,
@@ -368,19 +367,6 @@ function getType(
     } else {
       simpleTypesMap.set(key, newValue);
     }
-  }
-  if (
-    type.kind === "Model" &&
-    isModelWithAdditionalProperties(newValue) &&
-    !context.rlcOptions?.compatibilityMode
-  ) {
-    reportDiagnostic(context.program, {
-      code: "compatible-additional-properties",
-      format: {
-        modelName: type?.name ?? ""
-      },
-      target: type
-    });
   }
 
   return newValue;
@@ -1832,7 +1818,6 @@ export function emitCodeModel(
     options: dpgContext.rlcOptions ?? {},
     modularOptions: {
       sourceRoot: modularSourcesRoot,
-      compatibilityMode: !!dpgContext.rlcOptions?.compatibilityMode,
       experimentalExtensibleEnums:
         !!dpgContext.rlcOptions?.experimentalExtensibleEnums
     },

--- a/packages/typespec-ts/src/modular/emitModels.ts
+++ b/packages/typespec-ts/src/modular/emitModels.ts
@@ -223,11 +223,7 @@ export function buildModels(
         modelInterface.extends.push(p.alias ?? getType(p, p.format).name)
       );
       if (isModelWithAdditionalProperties(model)) {
-        addExtendedDictInfo(
-          model,
-          modelInterface,
-          codeModel.modularOptions.compatibilityMode
-        );
+        addExtendedDictInfo(model, modelInterface);
       }
 
       if (!modelsFile.getInterface(modelInterface.name)) {
@@ -327,8 +323,7 @@ function getExtensibleEnumDescription(model: ModularType): string | undefined {
 
 function addExtendedDictInfo(
   model: ModularType,
-  modelInterface: InterfaceStructure,
-  compatibilityMode: boolean = false
+  modelInterface: InterfaceStructure
 ) {
   if (
     (model.properties &&
@@ -342,16 +337,8 @@ function addExtendedDictInfo(
     modelInterface.extends.push(
       `Record<string, ${getType(model.elementType!).name ?? "any"}>`
     );
-  } else if (compatibilityMode) {
-    modelInterface.extends.push(`Record<string, any>`);
   } else {
-    modelInterface.properties?.push({
-      name: "additionalProperties",
-      docs: ["Additional properties"],
-      hasQuestionToken: true,
-      isReadonly: false,
-      type: `Record<string, ${getType(model.elementType!).name ?? "any"}>`
-    });
+    modelInterface.extends.push(`Record<string, any>`);
   }
 }
 

--- a/packages/typespec-ts/src/modular/modularCodeModel.ts
+++ b/packages/typespec-ts/src/modular/modularCodeModel.ts
@@ -13,7 +13,6 @@ import { Project } from "ts-morph";
 
 export interface ModularOptions {
   sourceRoot: string;
-  compatibilityMode: boolean;
   experimentalExtensibleEnums: boolean;
 }
 export interface ModularCodeModel {

--- a/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/tspconfig.yaml
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/dictionary/tspconfig.yaml
@@ -10,8 +10,6 @@ options:
     isTypeSpecTest: true
     enableOperationGroup: true
     isModularLibrary: true
-    # temporary only support legacy client for additional properties in modular
-    compatibilityMode: true
     packageDetails:
       name: "@msinternal/dictionary"
       description: "Dictionary Test Service"

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/tspconfig.yaml
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/additional-properties/tspconfig.yaml
@@ -10,8 +10,6 @@ options:
     isTypeSpecTest: true
     enableOperationGroup: true
     isModularLibrary: true
-    # temporary only support legacy client for additional properties in modular
-    compatibilityMode: true
     packageDetails:
       name: "@msinternal/additional-property"
       description: "additional Property Test Service"

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/tspconfig.yaml
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/nullable/tspconfig.yaml
@@ -10,8 +10,6 @@ options:
     isTypeSpecTest: true
     enableOperationGroup: true
     isModularLibrary: true
-    # temporary only support legacy client for additional properties in modular
-    compatibilityMode: true
     packageDetails:
       name: "@msinternal/nullable-property"
       description: "nullable Property Test Service"

--- a/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/tspconfig.yaml
+++ b/packages/typespec-ts/test/modularIntegration/generated/type/property/optionality/tspconfig.yaml
@@ -10,8 +10,6 @@ options:
     isTypeSpecTest: true
     enableOperationGroup: true
     isModularLibrary: true
-    # temporary only support legacy client for additional properties in modular
-    compatibilityMode: true
     packageDetails:
       name: "@msinternal/optional-property"
       description: "Optional Property Test Service"

--- a/packages/typespec-ts/test/modularUnit/modelsGenerator.spec.ts
+++ b/packages/typespec-ts/test/modularUnit/modelsGenerator.spec.ts
@@ -1939,10 +1939,6 @@ describe("spread record", () => {
     }
     op post(@body body: Vegetables): { @body body: Vegetables };
     `,
-      false,
-      false,
-      false,
-      true
     );
     assert.ok(modelFile);
     assert.isTrue(modelFile?.getFilePath()?.endsWith("/models/models.ts"));
@@ -2008,10 +2004,6 @@ describe("spread record", () => {
       }
       op post(@body body: A): { @body body: A };
     `,
-      false,
-      false,
-      false,
-      true
     );
     assert.ok(modelFile);
     assert.isTrue(modelFile?.getFilePath()?.endsWith("/models/models.ts"));

--- a/packages/typespec-ts/test/util/emitUtil.ts
+++ b/packages/typespec-ts/test/util/emitUtil.ts
@@ -303,7 +303,6 @@ export async function emitModularModelsFromTypeSpec(
   needOptions: boolean = false,
   withRawContent: boolean = false,
   needAzureCore: boolean = false,
-  compatibilityMode: boolean = false,
   mustEmptyDiagnostic: boolean = true,
   experimentalExtensibleEnums: boolean = false
 ) {
@@ -324,7 +323,6 @@ export async function emitModularModelsFromTypeSpec(
   let modelFile = undefined;
   if (clients && clients[0]) {
     dpgContext.rlcOptions!.isModularLibrary = true;
-    dpgContext.rlcOptions!.compatibilityMode = compatibilityMode;
     dpgContext.rlcOptions!.experimentalExtensibleEnums =
       experimentalExtensibleEnums;
     const rlcModels = await transformRLCModel(clients[0], dpgContext);


### PR DESCRIPTION
As @joheredi confirmed with @bterlson, we should just generate record of any for additional properties like what we used to do for mgmt plane. 

Therefore revert the compatibilityMode flag related logic. and since both Modular layer and RLC layer are using the same Record of any, we don't need to have any special serialize and deserialize logic for them. Customers will have to pass the rest api layer value datetime string like the below example by themselves. 

```
model Foo {
  ...Record<utcDateTime>
  prop: utcDateTIme;
}

```
closes https://github.com/Azure/autorest.typescript/issues/2506
closes https://github.com/Azure/autorest.typescript/issues/2471