### PR TITLE
[engsys] Use dev-tool command in tshy for monorepo

### DIFF
--- a/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
@@ -130,7 +130,7 @@ function getEsmDevDependencies({
   }
 
   return {
-    tshy: "^1.11.1",
+    tshy: "^2.0.0",
     ...testDevDependencies
   };
 }
@@ -228,12 +228,13 @@ function getEsmScripts({ moduleKind }: AzureMonorepoInfoConfig) {
   }
 
   return {
-    "build:test": "npm run clean && tshy && dev-tool run build-test",
+    "build:test":
+      "npm run clean && dev-tool run build-package && dev-tool run build-test",
     build:
-      "npm run clean && tshy && mkdirp ./review && dev-tool run extract-api",
+      "npm run clean && dev-tool run build-package && mkdirp ./review && dev-tool run extract-api",
     "test:node":
-      "npm run clean && tshy && npm run unit-test:node && npm run integration-test:node",
-    test: "npm run clean && tshy && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",
+      "npm run clean && dev-tool run build-package && npm run unit-test:node && npm run integration-test:node",
+    test: "npm run clean && dev-tool run build-package && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",
     "unit-test:browser":
       "npm run build:test && dev-tool run test:vitest --browser",
     "unit-test:node": "dev-tool run test:vitest"

--- a/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
@@ -119,20 +119,14 @@ function getEsmDevDependencies({
     return {};
   }
 
-  let testDevDependencies: Record<string, string> = {};
   if (withTests) {
-    testDevDependencies = {
+    return {
       "@vitest/browser": "^2.0.5",
       "@vitest/coverage-istanbul": "^2.0.5",
       playwright: "^1.41.2",
       vitest: "^2.0.5"
     };
-  }
-
-  return {
-    tshy: "^2.0.0",
-    ...testDevDependencies
-  };
+  } else return {};
 }
 
 function getCjsDevDependencies({

--- a/packages/rlc-common/test/integration/packageJson.spec.ts
+++ b/packages/rlc-common/test/integration/packageJson.spec.ts
@@ -296,19 +296,19 @@ describe("Package file generation", () => {
 
       expect(packageFile.scripts).to.have.property(
         "build:test",
-        "npm run clean && tshy && dev-tool run build-test"
+        "npm run clean && dev-tool run build-package && dev-tool run build-test"
       );
       expect(packageFile.scripts).to.have.property(
         "build",
-        "npm run clean && tshy && mkdirp ./review && dev-tool run extract-api"
+        "npm run clean && dev-tool run build-package && mkdirp ./review && dev-tool run extract-api"
       );
       expect(packageFile.scripts).to.have.property(
         "test:node",
-        "npm run clean && tshy && npm run unit-test:node && npm run integration-test:node"
+        "npm run clean && dev-tool run build-package && npm run unit-test:node && npm run integration-test:node"
       );
       expect(packageFile.scripts).to.have.property(
         "test",
-        "npm run clean && tshy && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test"
+        "npm run clean && dev-tool run build-package && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test"
       );
       expect(packageFile.scripts).to.have.property(
         "unit-test:browser",

--- a/packages/rlc-common/test/integration/packageJson.spec.ts
+++ b/packages/rlc-common/test/integration/packageJson.spec.ts
@@ -265,7 +265,6 @@ describe("Package file generation", () => {
       });
       const packageFileContent = buildPackageFile(model);
       const packageFile = JSON.parse(packageFileContent?.content ?? "{}");
-      expect(packageFile.devDependencies).to.have.property("tshy");
     });
 
     it("[esm] should include correct devDependencies with tests", () => {


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-for-js/issues/31211

This PR updates the codegen for ESM packages within the monorepo to use the `build-package` command instead of using tshy directly.

The changes have been made in the azure-sdk-for-js repo, this PR ensures codegen behaves.

## callout

this is my first PR in the autorest.typescript repo so please do assume I forgot / missed something and let me know what was missed. I was surprised that smoke tests did not fail, but maybe there's a different command to run them