### PR TITLE
upgrade dev dependencies for generated packages

### DIFF
--- a/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
+++ b/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
@@ -105,7 +105,7 @@ function regularAutorestPackage(
     module: `./dist-esm/index.js`,
     types: `./types/${packageDetails.nameWithoutScope}.d.ts`,
     devDependencies: {
-      "@microsoft/api-extractor": "^7.31.1",
+      "@microsoft/api-extractor": "^7.40.3",
       mkdirp: "^3.0.1",
       typescript: "~5.6.2",
       rimraf: "^5.0.0",
@@ -179,6 +179,7 @@ function regularAutorestPackage(
 
   if (azureSdkForJs) {
     packageInfo.devDependencies["@azure/dev-tool"] = "^1.0.0";
+    delete packageInfo.devDependencies["@microsoft/api-extractor"];
     delete packageInfo.devDependencies["rimraf"];
     delete packageInfo.devDependencies["mkdirp"];
     packageInfo.scripts["build"] =

--- a/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
+++ b/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/additional-properties.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/integration/generated/appconfiguration/package.json
+++ b/packages/autorest.typescript/test/integration/generated/appconfiguration/package.json
@@ -17,7 +17,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/appconfiguration.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/appconfigurationexport/package.json
+++ b/packages/autorest.typescript/test/integration/generated/appconfigurationexport/package.json
@@ -17,7 +17,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/appconfiguration.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/arrayConstraints/package.json
+++ b/packages/autorest.typescript/test/integration/generated/arrayConstraints/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/array-constraints-client.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/attestation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/attestation/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/attestation.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/azure-parameter-grouping.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/azureReport/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureReport/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/zzzAzureReport.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/package.json
@@ -17,7 +17,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/azure-special-properties.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyArray/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyArray/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-array.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyBoolean/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyBoolean/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-boolean.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-boolean-quirks.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyByte/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyByte/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-byte.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyComplex/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplex/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-complex.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/package.json
@@ -17,7 +17,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-complex-tracing.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyDate/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDate/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-date.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTime/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTime/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-datetime.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-datetime-rfc1123.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyDictionary/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDictionary/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-dictionary.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyDuration/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDuration/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-duration.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyFile/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyFile/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-file.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyFormData/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyFormData/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-formdata.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyInteger/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyInteger/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-integer.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyNumber/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyNumber/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-number.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyString/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyString/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-string.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/bodyTime/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyTime/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-time.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/constantParam/package.json
+++ b/packages/autorest.typescript/test/integration/generated/constantParam/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/constantParam.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/corecompattest/package.json
+++ b/packages/autorest.typescript/test/integration/generated/corecompattest/package.json
@@ -17,7 +17,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/petstore.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/customUrl/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrl/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/custom-url.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/custom-url-MoreOptions.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/customUrlPaging/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrlPaging/package.json
@@ -17,7 +17,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/custom-url-paging.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/datafactory/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datafactory/package.json
@@ -19,7 +19,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/datafactory.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/datalakestorage/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datalakestorage/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/datalakestorage.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/datasearch/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datasearch/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/data-search.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/package.json
@@ -19,7 +19,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/deviceprovisioning.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/domainservices/package.json
+++ b/packages/autorest.typescript/test/integration/generated/domainservices/package.json
@@ -19,7 +19,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/domainservices.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/extensibleEnums/package.json
+++ b/packages/autorest.typescript/test/integration/generated/extensibleEnums/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/extensible-enums.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/header/package.json
+++ b/packages/autorest.typescript/test/integration/generated/header/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/header.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/headerprefix/package.json
+++ b/packages/autorest.typescript/test/integration/generated/headerprefix/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/headerprefix.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/package.json
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/package.json
@@ -19,7 +19,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/healthcareapis.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/httpInfrastructure/package.json
+++ b/packages/autorest.typescript/test/integration/generated/httpInfrastructure/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/httpInfrastructure.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/iotspaces/package.json
+++ b/packages/autorest.typescript/test/integration/generated/iotspaces/package.json
@@ -17,7 +17,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/iotspaces.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/licenseHeader/package.json
+++ b/packages/autorest.typescript/test/integration/generated/licenseHeader/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/license-header.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/lro/package.json
+++ b/packages/autorest.typescript/test/integration/generated/lro/package.json
@@ -19,7 +19,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/lro.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/package.json
+++ b/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/package.json
@@ -18,7 +18,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/lro-parameterized-endpoints.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/mapperrequired/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mapperrequired/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/mapperrequired.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/mediaTypes/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypes/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-service.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-v3-client.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/package.json
@@ -18,7 +18,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-v3-lro-client.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/package.json
@@ -17,7 +17,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-service-tracing.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/modelFlattening/package.json
+++ b/packages/autorest.typescript/test/integration/generated/modelFlattening/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/model-flattening.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/multipleInheritance/package.json
+++ b/packages/autorest.typescript/test/integration/generated/multipleInheritance/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/multiple-inheritance.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/nameChecker/package.json
+++ b/packages/autorest.typescript/test/integration/generated/nameChecker/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/search-documents.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/noLicenseHeader/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noLicenseHeader/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/nolicense-header.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/noMappers/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noMappers/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/no-mappers.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/noOperation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noOperation/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/no-operation.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/nonStringEnum/package.json
+++ b/packages/autorest.typescript/test/integration/generated/nonStringEnum/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/non-string-num.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/objectType/package.json
+++ b/packages/autorest.typescript/test/integration/generated/objectType/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/object-type.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/odataDiscriminator/package.json
+++ b/packages/autorest.typescript/test/integration/generated/odataDiscriminator/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/odata-discriminator.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/operationgroupclash/package.json
+++ b/packages/autorest.typescript/test/integration/generated/operationgroupclash/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/operationgroupclash.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/optionalnull/package.json
+++ b/packages/autorest.typescript/test/integration/generated/optionalnull/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/optionalnull.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/paging/package.json
+++ b/packages/autorest.typescript/test/integration/generated/paging/package.json
@@ -20,7 +20,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/paging-service.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/pagingNoIterators/package.json
+++ b/packages/autorest.typescript/test/integration/generated/pagingNoIterators/package.json
@@ -18,7 +18,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/paging-no-iterators.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/patterntest/package.json
+++ b/packages/autorest.typescript/test/integration/generated/patterntest/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/pattern-test.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/integration/generated/petstore/package.json
+++ b/packages/autorest.typescript/test/integration/generated/petstore/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/petstore.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/readmeFileChecker/package.json
+++ b/packages/autorest.typescript/test/integration/generated/readmeFileChecker/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/keyvault-secrets.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/regexConstraint/package.json
+++ b/packages/autorest.typescript/test/integration/generated/regexConstraint/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/regex-constraint.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/report/package.json
+++ b/packages/autorest.typescript/test/integration/generated/report/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/zzzReport.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/requiredOptional/package.json
+++ b/packages/autorest.typescript/test/integration/generated/requiredOptional/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/required-optional.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/resources/package.json
+++ b/packages/autorest.typescript/test/integration/generated/resources/package.json
@@ -17,7 +17,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/resources.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/sealedchoice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/sealedchoice/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/sealedchoice.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/storageblob/package.json
+++ b/packages/autorest.typescript/test/integration/generated/storageblob/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/storageblob.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/storagefileshare/package.json
+++ b/packages/autorest.typescript/test/integration/generated/storagefileshare/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/storagefileshare.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/package.json
+++ b/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/subscriptionid-apiversion.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/textanalytics/package.json
+++ b/packages/autorest.typescript/test/integration/generated/textanalytics/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/textanalytics.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/url/package.json
+++ b/packages/autorest.typescript/test/integration/generated/url/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/url.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/url2/package.json
+++ b/packages/autorest.typescript/test/integration/generated/url2/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/url.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/urlMulti/package.json
+++ b/packages/autorest.typescript/test/integration/generated/urlMulti/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/url-multi.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev1/package.json
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev1/package.json
@@ -12,7 +12,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/useragent-corev1.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev2/package.json
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev2/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/useragent-corev2.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/uuid/package.json
+++ b/packages/autorest.typescript/test/integration/generated/uuid/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/uuid.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/validation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/validation/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/validation.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/xmlservice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/xmlservice/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/xml-service.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/package.json
+++ b/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/xms-error-responses.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/package.json
@@ -16,7 +16,6 @@
   "module": "./dist-esm/index.js",
   "types": "./types/zzzAzureReport.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
     "typescript": "~5.6.2",
     "dotenv": "^16.0.0",
     "@azure/dev-tool": "^1.0.0"

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -62,7 +63,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -47,7 +46,7 @@
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-env-preprocessor": "^0.1.1",
-    "karma-firefox-launcher": "^2.1.2",
+    "karma-firefox-launcher": "^2.1.3",
     "karma-junit-reporter": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",
@@ -63,6 +62,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "@azure/identity": "^4.2.1",
     "autorest": "latest",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -51,7 +51,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
@@ -35,7 +35,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -46,6 +45,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -45,7 +46,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
@@ -51,7 +51,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
@@ -35,7 +35,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -46,6 +45,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -45,7 +46,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/report/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/report/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/zzzReport.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
@@ -51,7 +51,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
@@ -51,7 +51,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -49,7 +48,7 @@
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-env-preprocessor": "^0.1.1",
-    "karma-firefox-launcher": "^2.1.2",
+    "karma-firefox-launcher": "^2.1.3",
     "karma-junit-reporter": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",
@@ -65,6 +64,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -64,7 +65,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
@@ -35,7 +35,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "@azure/identity": "^4.2.1",
     "autorest": "latest",

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-mv-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-mv-rest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-mv-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-mv-rest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-mv-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-mv-rest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -49,7 +48,7 @@
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-env-preprocessor": "^0.1.1",
-    "karma-firefox-launcher": "^2.1.2",
+    "karma-firefox-launcher": "^2.1.3",
     "karma-junit-reporter": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",
@@ -65,6 +64,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -64,7 +65,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
@@ -35,7 +35,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "@azure/identity": "^4.2.1",
     "autorest": "latest",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-package-deploymentscripts-2019-10-preview.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-features-2015-12/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-features-2015-12/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-package-features-2015-12.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-links-2016-09/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-links-2016-09/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-package-links-2016-09.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-locks-2016-09/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-locks-2016-09/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-package-locks-2016-09.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-package-managedapplications-2018-06.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-policy-2019-09/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-policy-2019-09/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-package-policy-2019-09.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/arm-package-resources-2019-08.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/arm-package-subscriptions-2019-06.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/compute-resource-manager.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/cosmos-db-resource-manager.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/graphrbac-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/graphrbac-data-plane/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/graphrbac-data-plane.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/keyvault-resource-manager.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/monitor-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/monitor-data-plane/package.json
@@ -17,7 +17,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/monitor-data-plane.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/msi-resource-manager.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/network-resource-manager.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/networkcloud-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/networkcloud-resource-manager/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/networkcloud-resource-manager.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/sql-resource-manager.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/storage-resource-manager.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
@@ -20,7 +20,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/web-resource-manager.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.31.1",
+    "@microsoft/api-extractor": "^7.40.3",
     "mkdirp": "^3.0.1",
     "typescript": "~5.6.2",
     "rimraf": "^5.0.0",

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "autorest": "latest",
     "source-map-support": "^0.5.9",

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
+    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -43,7 +44,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.0",
-    "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
     "eslint": "^9.9.0",
     "typescript": "~5.6.2",
@@ -44,6 +43,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "@microsoft/api-extractor": "^7.40.3",
     "rimraf": "^5.0.5",
     "mkdirp": "^3.0.1"
   },

--- a/packages/rlc-common/src/metadata/packageJson/azurePackageCommon.ts
+++ b/packages/rlc-common/src/metadata/packageJson/azurePackageCommon.ts
@@ -103,7 +103,7 @@ function getAzurePackageCjsDevDependencies({
     "karma-chrome-launcher": "^3.0.0",
     "karma-coverage": "^2.0.0",
     "karma-env-preprocessor": "^0.1.1",
-    "karma-firefox-launcher": "^2.1.2",
+    "karma-firefox-launcher": "^2.1.3",
     "karma-junit-reporter": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-mocha": "^2.0.1",

--- a/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
@@ -38,12 +38,14 @@ export function buildAzureMonorepoPackage(config: AzureMonorepoInfoConfig) {
 export function getAzureMonorepoDependencies(config: AzureMonorepoInfoConfig) {
   const esmDevDependencies = getEsmDevDependencies(config);
   const cjsDevDependencies = getCjsDevDependencies(config);
+  const azurePackageDevDependencies = getAzurePackageDevDependencies(config);
+  delete azurePackageDevDependencies["tshy"];
   return {
     dependencies: {
       ...getAzurePackageDependencies(config)
     },
     devDependencies: {
-      ...getAzurePackageDevDependencies(config),
+      ...azurePackageDevDependencies,
       "@azure/dev-tool": "^1.0.0",
       "@azure/eslint-plugin-azure-sdk": "^3.0.0",
       ...esmDevDependencies,
@@ -137,7 +139,7 @@ function getCjsDevDependencies({
       "karma-chrome-launcher": "^3.0.0",
       "karma-coverage": "^2.0.0",
       "karma-env-preprocessor": "^0.1.1",
-      "karma-firefox-launcher": "^1.1.0",
+      "karma-firefox-launcher": "^2.1.3",
       "karma-junit-reporter": "^2.0.1",
       "karma-mocha-reporter": "^2.2.5",
       "karma-mocha": "^2.0.1",

--- a/packages/rlc-common/src/metadata/packageJson/buildAzureStandalonePackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureStandalonePackage.ts
@@ -45,6 +45,7 @@ function getAzureStandaloneDependencies(
     },
     devDependencies: {
       ...getStandaloneDevDependencies(config),
+      "@microsoft/api-extractor": "^7.40.3",
       rimraf: "^5.0.5",
       mkdirp: "^3.0.1"
     }

--- a/packages/rlc-common/src/metadata/packageJson/buildFlavorlessPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildFlavorlessPackage.ts
@@ -20,7 +20,7 @@ export function buildFlavorlessPackage(config: PackageCommonInfoConfig) {
       ...getCommonPackageDevDependencies(config),
       "@microsoft/api-extractor": "^7.40.3",
       rimraf: "^5.0.5",
-      mkdirp: "^3.0.1",
+      mkdirp: "^3.0.1"
     },
     dependencies: {
       ...commonPackageDependencies,

--- a/packages/rlc-common/src/metadata/packageJson/buildFlavorlessPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildFlavorlessPackage.ts
@@ -18,8 +18,9 @@ export function buildFlavorlessPackage(config: PackageCommonInfoConfig) {
     scripts: getFlavorlessScripts(config),
     devDependencies: {
       ...getCommonPackageDevDependencies(config),
+      "@microsoft/api-extractor": "^7.40.3",
       rimraf: "^5.0.5",
-      mkdirp: "^3.0.1"
+      mkdirp: "^3.0.1",
     },
     dependencies: {
       ...commonPackageDependencies,

--- a/packages/rlc-common/src/metadata/packageJson/packageCommon.ts
+++ b/packages/rlc-common/src/metadata/packageJson/packageCommon.ts
@@ -44,7 +44,7 @@ export function getCommonPackageDevDependencies(
   return {
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    eslint: "^8.55.0",
+    eslint: "^9.9.0",
     typescript: "~5.6.2",
     ...getEsmDevDependencies(config)
   };

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/sdk/test/arm-test/package.json
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/sdk/test/arm-test/package.json
@@ -59,7 +59,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/ai/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/ai/generated/typespec-ts/package.json
@@ -57,7 +57,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "rimraf": "^5.0.5",

--- a/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/package.json
@@ -56,7 +56,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/authoring/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/authoring/generated/typespec-ts/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/package.json
@@ -54,7 +54,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/package.json
@@ -54,7 +54,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/confidentialLedger/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/confidentialLedger/generated/typespec-ts/package.json
@@ -51,7 +51,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "rimraf": "^5.0.5",

--- a/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/package.json
@@ -54,7 +54,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "rimraf": "^5.0.5",

--- a/packages/typespec-test/test/contoso/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/contoso/generated/typespec-ts/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/customWrapper/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/customWrapper/generated/typespec-ts/package.json
@@ -51,7 +51,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/package.json
@@ -54,7 +54,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/faceai/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/faceai/generated/typespec-ts/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/healthInsights_radiologyinsights/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/healthInsights_radiologyinsights/generated/typespec-ts/package.json
@@ -56,7 +56,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/healthInsights_trialmatcher/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/healthInsights_trialmatcher/generated/typespec-ts/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/package.json
@@ -58,7 +58,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/loadTest/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/loadTest/generated/typespec-ts/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/openai/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/openai/generated/typespec-ts/package.json
@@ -53,7 +53,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/openai_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/openai_modular/generated/typespec-ts/package.json
@@ -54,7 +54,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/openai_non_branded/generated/typespec-ts/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "rimraf": "^5.0.5",

--- a/packages/typespec-test/test/overloads_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/overloads_modular/generated/typespec-ts/package.json
@@ -55,7 +55,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/package.json
@@ -55,7 +55,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "rimraf": "^5.0.5",

--- a/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/package.json
@@ -55,7 +55,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "rimraf": "^5.0.5",

--- a/packages/typespec-test/test/spread/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/spread/generated/typespec-ts/package.json
@@ -55,7 +55,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/todo_non_branded/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/todo_non_branded/generated/typespec-ts/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "rimraf": "^5.0.5",

--- a/packages/typespec-test/test/translator/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/translator/generated/typespec-ts/package.json
@@ -51,7 +51,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/package.json
@@ -58,7 +58,7 @@
     "dotenv": "^16.0.0",
     "@microsoft/api-extractor": "^7.40.3",
     "@types/node": "^18.0.0",
-    "eslint": "^8.55.0",
+    "eslint": "^9.9.0",
     "typescript": "~5.6.2",
     "tshy": "^2.0.0",
     "@azure/identity": "^4.2.1",


### PR DESCRIPTION
- eslint versino to ^9.9.0
- don't add tshy or api-extractor for js repo
- update karma-firefox-launcher to ^2.1.3
- regen test baselines