### PR TITLE
Response header should be `string` in RLC

### DIFF
--- a/packages/typespec-ts/src/transform/transformResponses.ts
+++ b/packages/typespec-ts/src/transform/transformResponses.ts
@@ -152,7 +152,10 @@ function transformHeaders(
         usage: [SchemaContext.Output],
         relevantProperty: value
       }) as Schema;
-      const type = getTypeName(typeSchema, [SchemaContext.Output]);
+      let type = getTypeName(typeSchema, [SchemaContext.Output]);
+      if (type !== "string") {
+        type = "string";
+      }
       getImportedModelName(typeSchema, [SchemaContext.Output])?.forEach(
         importedModels.add,
         importedModels

--- a/packages/typespec-ts/test/azureIntegration/encodeDatetime.spec.ts
+++ b/packages/typespec-ts/test/azureIntegration/encodeDatetime.spec.ts
@@ -205,13 +205,12 @@ describe("EncodeDatetimeClient Rest Client", () => {
       assert.strictEqual(result.headers.value, "Fri, 26 Aug 2022 14:38:00 GMT");
     });
 
-    //TODO revert this skipped case after merging https://github.com/microsoft/typespec/pull/6423
-    it.skip(`should get unix-timestamp header`, async () => {
+    it(`should get unix-timestamp header`, async () => {
       const result = await client
         .path(`/encode/datetime/responseheader/unix-timestamp`)
         .get();
       assert.strictEqual(result.status, "204");
-      assert.strictEqual(result.headers.value, 1686566864);
+      assert.strictEqual(result.headers.value, "1686566864");
     });
   });
 });

--- a/packages/typespec-ts/test/azureIntegration/generated/encode/datetime/src/index.d.ts
+++ b/packages/typespec-ts/test/azureIntegration/generated/encode/datetime/src/index.d.ts
@@ -337,7 +337,7 @@ export declare interface ResponseHeaderUnixTimestamp {
 }
 
 export declare interface ResponseHeaderUnixTimestamp204Headers {
-    value: number;
+    value: string;
 }
 
 export declare interface ResponseHeaderUnixTimestamp204Response extends HttpResponse {

--- a/packages/typespec-ts/test/integration/encodeDatetime.spec.ts
+++ b/packages/typespec-ts/test/integration/encodeDatetime.spec.ts
@@ -205,13 +205,12 @@ describe("EncodeDatetimeClient Rest Client", () => {
       assert.strictEqual(result.headers.value, "Fri, 26 Aug 2022 14:38:00 GMT");
     });
 
-    //TODO revert this skipped case after merging https://github.com/microsoft/typespec/pull/6423
-    it.skip(`should get unix-timestamp header`, async () => {
+    it(`should get unix-timestamp header`, async () => {
       const result = await client
         .path(`/encode/datetime/responseheader/unix-timestamp`)
         .get();
       assert.strictEqual(result.status, "204");
-      assert.strictEqual(result.headers.value, 1686566864);
+      assert.strictEqual(result.headers.value, "1686566864");
     });
   });
 });

--- a/packages/typespec-ts/test/integration/generated/encode/datetime/src/index.d.ts
+++ b/packages/typespec-ts/test/integration/generated/encode/datetime/src/index.d.ts
@@ -337,7 +337,7 @@ export declare interface ResponseHeaderUnixTimestamp {
 }
 
 export declare interface ResponseHeaderUnixTimestamp204Headers {
-    value: number;
+    value: string;
 }
 
 export declare interface ResponseHeaderUnixTimestamp204Response extends HttpResponse {

--- a/packages/typespec-ts/test/unit/responsesGenerator.spec.ts
+++ b/packages/typespec-ts/test/unit/responsesGenerator.spec.ts
@@ -238,7 +238,7 @@ describe("Responses.ts", () => {
       );
     });
 
-    it("should handle int/decimal/decimal128/int8 with encode `string` in response headers", async () => {
+    it.only("should handle int/decimal/decimal128/int8 with encode `string` in response headers", async () => {
       const responses = await emitResponsesFromTypeSpec(
         `
       alias SimpleModel = {
@@ -257,6 +257,10 @@ describe("Responses.ts", () => {
         @header
         @encode(DurationKnownEncoding.seconds, float)
         z: duration;
+        @header
+        number: int64;
+        @header
+        float: float;
       };
       @route("/decimal/prop/encode")
       @get
@@ -278,7 +282,9 @@ describe("Responses.ts", () => {
             "y": string;
             "value": string;
             "input": string;
-            "z": number;
+            "z": string;
+            "number": string;
+            "float": string;
         }
 
         /** The request has succeeded. */


### PR DESCRIPTION
fixes https://github.com/Azure/autorest.typescript/issues/3109