### PR TITLE
Fix wrong eslint dependency and bump version

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       '@autorest/testmodeler': ^2.6.1
       '@azure-rest/core-client': ^1.4.0
       '@azure-tools/codegen': ^2.9.1
-      '@azure-tools/rlc-common': workspace:^0.40.1
+      '@azure-tools/rlc-common': workspace:^0.40.2
       '@azure-tools/test-recorder': ^3.0.0
       '@azure/abort-controller': ^2.1.2
       '@azure/core-auth': ^1.6.0
@@ -196,7 +196,7 @@ importers:
       '@azure-tools/typespec-azure-resource-manager': ^0.56.1
       '@azure-tools/typespec-azure-rulesets': ^0.56.0
       '@azure-tools/typespec-client-generator-core': ^0.56.2
-      '@azure-tools/typespec-ts': workspace:^0.40.1
+      '@azure-tools/typespec-ts': workspace:^0.40.2
       '@types/mocha': ^5.2.7
       '@types/node': ^18.0.0
       '@typespec/compiler': ^1.0.0
@@ -234,7 +234,7 @@ importers:
     specifiers:
       '@azure-rest/core-client': ^2.3.1
       '@azure-tools/azure-http-specs': ^0.1.0-alpha.17-dev.0
-      '@azure-tools/rlc-common': workspace:^0.40.1
+      '@azure-tools/rlc-common': workspace:^0.40.2
       '@azure-tools/typespec-autorest': ^0.56.0
       '@azure-tools/typespec-azure-core': ^0.56.0
       '@azure-tools/typespec-azure-resource-manager': ^0.56.1

--- a/packages/autorest.typescript/CHANGELOG.md
+++ b/packages/autorest.typescript/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.41 (2025-05-22)
+
+- [Bugfix] Fix wrong eslint dependency
+
 ## 6.0.40 (2025-05-20)
 
 - [Feature] Remove camel-case style option. Please refer to [#3167](https://github.com/Azure/autorest.typescript/pull/3167)

--- a/packages/autorest.typescript/package.json
+++ b/packages/autorest.typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/typescript",
-  "version": "6.0.40",
+  "version": "6.0.41",
   "scripts": {
     "build": "tsc -p . && npm run copyFiles",
     "build:test:browser:rlc": "tsc -p tsconfig.browser-test.json && ts-node test/commands/prepare-deps.ts --browser && webpack --config webpack.config.test.js --env mode=rlc",
@@ -77,7 +77,7 @@
     "source-map-support": "^0.5.16",
     "ts-morph": "^23.0.0",
     "@azure/core-auth": "^1.6.0",
-    "@azure-tools/rlc-common": "workspace:^0.40.1"
+    "@azure-tools/rlc-common": "workspace:^0.40.2"
   },
   "devDependencies": {
     "@azure-tools/test-recorder": "^3.0.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -59,7 +59,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.6.0",
     "@types/node": "^18.0.0",
-    "@eslint": "^9.9.0",
+    "eslint": "^9.9.0",
     "autorest": "latest",
     "typescript": "~5.8.2"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -57,7 +57,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.6.0",
     "@types/node": "^18.0.0",
-    "@eslint": "^9.9.0",
+    "eslint": "^9.9.0",
     "autorest": "latest",
     "typescript": "~5.8.2"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
@@ -57,7 +57,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.6.0",
     "@types/node": "^18.0.0",
-    "@eslint": "^9.9.0",
+    "eslint": "^9.9.0",
     "autorest": "latest",
     "typescript": "~5.8.2"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
@@ -57,7 +57,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.6.0",
     "@types/node": "^18.0.0",
-    "@eslint": "^9.9.0",
+    "eslint": "^9.9.0",
     "autorest": "latest",
     "typescript": "~5.8.2"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
@@ -57,7 +57,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^4.6.0",
     "@types/node": "^18.0.0",
-    "@eslint": "^9.9.0",
+    "eslint": "^9.9.0",
     "autorest": "latest",
     "typescript": "~5.8.2"
   },

--- a/packages/rlc-common/CHANGELOG.md
+++ b/packages/rlc-common/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.40.2 (2025-05-22)
+
+- [Bugfix] Fix wrong eslint dependency
+
 ## 0.40.1 (2025-05-20)
 
 - [Feature] Remove camel-case style option. Please refer to [#3167](https://github.com/Azure/autorest.typescript/pull/3167)

--- a/packages/rlc-common/package.json
+++ b/packages/rlc-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/rlc-common",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
@@ -55,18 +55,18 @@ export function getAzureMonorepoDependencies(config: AzureMonorepoInfoConfig) {
 
   const testDeps = withTests
     ? {
-        "@vitest/browser": !shouldUsePnpmDep ? "^3.0.9" : "catalog:testing",
-        "@vitest/coverage-istanbul": !shouldUsePnpmDep
-          ? "^3.0.9"
-          : "catalog:testing",
-        dotenv: !shouldUsePnpmDep ? "^16.0.0" : "catalog:testing",
-        playwright: !shouldUsePnpmDep ? "^1.50.1" : "catalog:testing",
-        typescript: !shouldUsePnpmDep ? "~5.8.2" : "catalog:",
-        vitest: !shouldUsePnpmDep ? "^3.0.9" : "catalog:testing"
-      }
+      "@vitest/browser": !shouldUsePnpmDep ? "^3.0.9" : "catalog:testing",
+      "@vitest/coverage-istanbul": !shouldUsePnpmDep
+        ? "^3.0.9"
+        : "catalog:testing",
+      dotenv: !shouldUsePnpmDep ? "^16.0.0" : "catalog:testing",
+      playwright: !shouldUsePnpmDep ? "^1.50.1" : "catalog:testing",
+      typescript: !shouldUsePnpmDep ? "~5.8.2" : "catalog:",
+      vitest: !shouldUsePnpmDep ? "^3.0.9" : "catalog:testing"
+    }
     : {
-        typescript: !shouldUsePnpmDep ? "~5.8.2" : "catalog:"
-      };
+      typescript: !shouldUsePnpmDep ? "~5.8.2" : "catalog:"
+    };
 
   return {
     dependencies: runtimeDeps,
@@ -86,7 +86,7 @@ export function getAzureMonorepoDependencies(config: AzureMonorepoInfoConfig) {
         : "workspace:*",
       "@azure/identity": !shouldUsePnpmDep ? "^4.6.0" : "catalog:internal",
       "@types/node": !shouldUsePnpmDep ? "^18.0.0" : "catalog:",
-      "@eslint": !shouldUsePnpmDep ? "^9.9.0" : "catalog:",
+      "eslint": !shouldUsePnpmDep ? "^9.9.0" : "catalog:",
       ...(config.specSource === "Swagger" && {
         autorest: !shouldUsePnpmDep ? "latest" : "catalog:"
       }),
@@ -166,9 +166,8 @@ function getAzureMonorepoScripts(config: AzureMonorepoInfoConfig) {
     "build:samples": config.withSamples
       ? "tsc -p tsconfig.samples.json && dev-tool samples publish -f"
       : "echo skipped",
-    "check-format": `dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}" ${
-      config.withSamples ? '"samples-dev/*.ts"' : ""
-    }`,
+    "check-format": `dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}" ${config.withSamples ? '"samples-dev/*.ts"' : ""
+      }`,
     clean:
       "dev-tool run vendored rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "execute:samples": config.withSamples
@@ -176,9 +175,8 @@ function getAzureMonorepoScripts(config: AzureMonorepoInfoConfig) {
       : "echo skipped",
     "extract-api":
       "dev-tool run vendored rimraf review && dev-tool run extract-api",
-    format: `dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}" ${
-      config.withSamples ? '"samples-dev/*.ts"' : ""
-    }`,
+    format: `dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}" ${config.withSamples ? '"samples-dev/*.ts"' : ""
+      }`,
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
     "generate:client": "echo skipped",

--- a/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
@@ -55,18 +55,18 @@ export function getAzureMonorepoDependencies(config: AzureMonorepoInfoConfig) {
 
   const testDeps = withTests
     ? {
-      "@vitest/browser": !shouldUsePnpmDep ? "^3.0.9" : "catalog:testing",
-      "@vitest/coverage-istanbul": !shouldUsePnpmDep
-        ? "^3.0.9"
-        : "catalog:testing",
-      dotenv: !shouldUsePnpmDep ? "^16.0.0" : "catalog:testing",
-      playwright: !shouldUsePnpmDep ? "^1.50.1" : "catalog:testing",
-      typescript: !shouldUsePnpmDep ? "~5.8.2" : "catalog:",
-      vitest: !shouldUsePnpmDep ? "^3.0.9" : "catalog:testing"
-    }
+        "@vitest/browser": !shouldUsePnpmDep ? "^3.0.9" : "catalog:testing",
+        "@vitest/coverage-istanbul": !shouldUsePnpmDep
+          ? "^3.0.9"
+          : "catalog:testing",
+        dotenv: !shouldUsePnpmDep ? "^16.0.0" : "catalog:testing",
+        playwright: !shouldUsePnpmDep ? "^1.50.1" : "catalog:testing",
+        typescript: !shouldUsePnpmDep ? "~5.8.2" : "catalog:",
+        vitest: !shouldUsePnpmDep ? "^3.0.9" : "catalog:testing"
+      }
     : {
-      typescript: !shouldUsePnpmDep ? "~5.8.2" : "catalog:"
-    };
+        typescript: !shouldUsePnpmDep ? "~5.8.2" : "catalog:"
+      };
 
   return {
     dependencies: runtimeDeps,
@@ -86,7 +86,7 @@ export function getAzureMonorepoDependencies(config: AzureMonorepoInfoConfig) {
         : "workspace:*",
       "@azure/identity": !shouldUsePnpmDep ? "^4.6.0" : "catalog:internal",
       "@types/node": !shouldUsePnpmDep ? "^18.0.0" : "catalog:",
-      "eslint": !shouldUsePnpmDep ? "^9.9.0" : "catalog:",
+      eslint: !shouldUsePnpmDep ? "^9.9.0" : "catalog:",
       ...(config.specSource === "Swagger" && {
         autorest: !shouldUsePnpmDep ? "latest" : "catalog:"
       }),
@@ -166,8 +166,9 @@ function getAzureMonorepoScripts(config: AzureMonorepoInfoConfig) {
     "build:samples": config.withSamples
       ? "tsc -p tsconfig.samples.json && dev-tool samples publish -f"
       : "echo skipped",
-    "check-format": `dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}" ${config.withSamples ? '"samples-dev/*.ts"' : ""
-      }`,
+    "check-format": `dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}" ${
+      config.withSamples ? '"samples-dev/*.ts"' : ""
+    }`,
     clean:
       "dev-tool run vendored rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "execute:samples": config.withSamples
@@ -175,8 +176,9 @@ function getAzureMonorepoScripts(config: AzureMonorepoInfoConfig) {
       : "echo skipped",
     "extract-api":
       "dev-tool run vendored rimraf review && dev-tool run extract-api",
-    format: `dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}" ${config.withSamples ? '"samples-dev/*.ts"' : ""
-      }`,
+    format: `dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}" ${
+      config.withSamples ? '"samples-dev/*.ts"' : ""
+    }`,
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
     "generate:client": "echo skipped",

--- a/packages/typespec-test/package.json
+++ b/packages/typespec-test/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "@azure-tools/typespec-ts": "workspace:^0.40.1",
+    "@azure-tools/typespec-ts": "workspace:^0.40.2",
     "@typespec/openapi": "^1.0.0",
     "@azure-tools/typespec-autorest": "^0.56.0",
     "@typespec/openapi3": "^1.0.0",

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/sdk/test/arm-test/metadata.json
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/sdk/test/arm-test/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2023-11-15",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/ai/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/ai/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2024-07-01-preview",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "v1.1",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/authoring/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/authoring/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2022-05-15-preview",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2023-05-01.17.0",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2023-10-01-preview",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/confidentialLedger/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/confidentialLedger/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2022-05-13",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2024-09-01",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/contoso/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/contoso/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2022-11-01-preview",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/customWrapper/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/customWrapper/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2022-05-15-preview",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2024-06-01",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/faceai/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/faceai/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "v1.2",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/healthInsights_radiologyinsights/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/healthInsights_radiologyinsights/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2023-09-01-preview",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/healthInsights_trialmatcher/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/healthInsights_trialmatcher/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2023-03-01-preview",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/metadata.json
@@ -1,3 +1,3 @@
 {
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/loadTest/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/loadTest/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2022-11-01",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2024-05-01-preview",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/nestedClient/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/nestedClient/generated/typespec-ts/metadata.json
@@ -1,3 +1,3 @@
 {
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/openai/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/openai/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2023-08-01-preview",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/metadata.json
@@ -1,3 +1,3 @@
 {
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/openai_modular/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/openai_modular/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2024-06-01",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/overloads_modular/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/overloads_modular/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2022-08-30",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/parametrizedHost/generated/typespec-ts/metadata.json
@@ -1,3 +1,3 @@
 {
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/schemaRegistry/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "2023-07-01",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/spread/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/spread/generated/typespec-ts/metadata.json
@@ -1,3 +1,3 @@
 {
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/translator/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/translator/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "3.0",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/metadata.json
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/metadata.json
@@ -1,4 +1,4 @@
 {
   "apiVersion": "1.0.0",
-  "emitterVersion": "0.40.1"
+  "emitterVersion": "0.40.2"
 }

--- a/packages/typespec-ts/CHANGELOG.md
+++ b/packages/typespec-ts/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.40.2 (2025-05-22)
+
+- [Bugfix] Fix wrong eslint dependency
+
 ## 0.40.1 (2025-05-20)
 
 - [Feature] Remove camel-case style option. Please refer to [#3167](https://github.com/Azure/autorest.typescript/pull/3167)

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-ts",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "An experimental TypeSpec emitter for TypeScript RLC",
   "main": "dist/src/index.js",
   "type": "module",
@@ -122,7 +122,7 @@
     "@typespec/xml": "^0.70.0"
   },
   "dependencies": {
-    "@azure-tools/rlc-common": "workspace:^0.40.1",
+    "@azure-tools/rlc-common": "workspace:^0.40.2",
     "fs-extra": "^11.1.0",
     "lodash": "^4.17.21",
     "prettier": "^3.3.3",


### PR DESCRIPTION
fixes https://dev.azure.com/azure-sdk/public/_build/results?buildId=4896127&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692 and comment https://github.com/Azure/autorest.typescript/pull/3200#discussion_r2102016811

```
[WARN]:     
08:49:55.956 cmdout E 	[automation_generate.sh] [WARN]:     ERROR: Invalid package name "@eslint": name can only contain URL-friendly
08:49:55.956 cmdout 	[automation_generate.sh] [WARN]:     characters
08:49:55.956 cmdout E 	[automation_generate.sh] [ERROR]:   stdout:
```
