### PR TITLE
[pnpm migration] switch from "npm pack" to "pnpm pack"

### DIFF
--- a/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
+++ b/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
@@ -131,7 +131,7 @@ function regularAutorestPackage(
         "npm run clean && tshy && npm run extract-api",
       minify: `uglifyjs -c -m --comments --source-map "content='./dist/index.js.map'" -o ./dist/index.min.js ./dist/index.js`,
       prepack: "npm run build",
-      pack: "npm pack 2>&1",
+      pack: `${shouldUsePnpmDep && azureSdkForJs ? "pnpm" : "npm"} pack 2>&1`,
       "extract-api": "rimraf review && mkdirp ./review && api-extractor run --local",
       lint: "echo skipped",
       clean:

--- a/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
@@ -190,6 +190,7 @@ function getAzureMonorepoScripts(config: AzureMonorepoInfoConfig) {
     lint: skipLinting
       ? "echo skipped"
       : "eslint package.json api-extractor.json src test",
+    pack: `${config.shouldUsePnpmDep ? "pnpm" : "npm"} pack 2>&1`,
     ...esmScripts,
     ...cjsScripts,
     "update-snippets": "dev-tool run update-snippets"

--- a/packages/rlc-common/test/integration/mockHelper.ts
+++ b/packages/rlc-common/test/integration/mockHelper.ts
@@ -20,6 +20,7 @@ export type TestModelConfig = {
   hasPaging?: boolean;
   isModularLibrary?: boolean;
   azureSdkForJs?: boolean;
+  shouldUsePnpmDep?: boolean;
   azureArm?: boolean;
 };
 
@@ -51,7 +52,8 @@ export function createMockModel(config: TestModelConfig = {}): RLCModel {
       moduleKind: config.moduleKind,
       sourceFrom: config.source ?? "TypeSpec",
       isModularLibrary: config.isModularLibrary ?? false,
-      azureArm: config.azureArm ?? false
+      azureArm: config.azureArm ?? false,
+      shouldUsePnpmDep: config.shouldUsePnpmDep ?? false
     },
     helperDetails: {
       hasPaging: config.hasPaging ?? false,

--- a/packages/rlc-common/test/integration/packageJson.spec.ts
+++ b/packages/rlc-common/test/integration/packageJson.spec.ts
@@ -449,6 +449,21 @@ describe("Package file generation", () => {
         "echo skipped"
       );
     });
+    it("[esm] should include correct scripts with pack", () => {
+      const model = createMockModel({
+        ...baseConfig,
+        moduleKind: "esm",
+        withTests: true,
+        shouldUsePnpmDep: true
+      });
+      const packageFileContent = buildPackageFile(model);
+      const packageFile = JSON.parse(packageFileContent?.content ?? "{}");
+
+      expect(packageFile.scripts).to.have.property(
+        "pack",
+        "pnpm pack 2>&1"
+      );
+    });
   });
 
   describe("Azure flavor for standalone library", () => {


### PR DESCRIPTION
so that the "workspace:" version specifiers are replaced with real versions