### PR TITLE
[pnpm migration] use "workspace:^"

### DIFF
--- a/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
+++ b/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
@@ -90,15 +90,15 @@ function regularAutorestPackage(
     },
     dependencies: {
       ...(hasLro && { "@azure/core-lro": shouldUsePnpmDep && azureSdkForJs ? "catalog:corelrov2" : "^2.5.4" }),
-      ...(hasLro && { "@azure/abort-controller": shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^2.1.2" }),
-      ...(hasAsyncIterators && { "@azure/core-paging": shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^1.6.2" }),
-      ...(useCoreV2 && { "@azure/core-client": shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^1.9.2" }),
-      ...(useCoreV2 && addCredentials && { "@azure/core-auth": shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^1.9.0" }),
+      ...(hasLro && { "@azure/abort-controller": shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^2.1.2" }),
+      ...(hasAsyncIterators && { "@azure/core-paging": shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^1.6.2" }),
+      ...(useCoreV2 && { "@azure/core-client": shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^1.9.2" }),
+      ...(useCoreV2 && addCredentials && { "@azure/core-auth": shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^1.9.0" }),
       ...(useCoreV2 && {
-        "@azure/core-rest-pipeline": shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^1.19.0"
+        "@azure/core-rest-pipeline": shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^1.19.0"
       }),
       ...(tracingInfo && {
-        "@azure/core-tracing": shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^1.2.0"
+        "@azure/core-tracing": shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^1.2.0"
       }),
       tslib: shouldUsePnpmDep && azureSdkForJs ? "catalog:" : "^2.8.1"
     },
@@ -181,7 +181,7 @@ function regularAutorestPackage(
     packageInfo.homepage = `https://github.com/Azure/azure-sdk-for-js/tree/main/${azureOutputDirectory}`;
   }
   if (azureSdkForJs) {
-    packageInfo.devDependencies["@azure/dev-tool"] = shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^1.0.0";
+    packageInfo.devDependencies["@azure/dev-tool"] = shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^1.0.0";
     delete packageInfo.devDependencies["@microsoft/api-extractor"];
     delete packageInfo.devDependencies["rimraf"];
     delete packageInfo.devDependencies["mkdirp"];
@@ -206,12 +206,12 @@ function regularAutorestPackage(
 
   if (generateTest) {
     packageInfo.devDependencies["@azure/identity"] = shouldUsePnpmDep && azureSdkForJs ? "catalog:internal" : "^4.6.0";
-    packageInfo.devDependencies["@azure/logger"] = shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^1.1.4";
+    packageInfo.devDependencies["@azure/logger"] = shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^1.1.4";
     // TODO need unify the version when 4.1.0 released
-    packageInfo.devDependencies["@azure-tools/test-recorder"] = azureSdkForJs ? shouldUsePnpmDep ? "workspace:*" : "^4.1.0" : "^4.0.0";
-    packageInfo.devDependencies["@azure-tools/test-credential"] = shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^2.0.0";
+    packageInfo.devDependencies["@azure-tools/test-recorder"] = azureSdkForJs ? shouldUsePnpmDep ? "workspace:^" : "^4.1.0" : "^4.0.0";
+    packageInfo.devDependencies["@azure-tools/test-credential"] = shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^2.0.0";
     if (azureSdkForJs) {
-      packageInfo.devDependencies["@azure-tools/test-utils-vitest"] = shouldUsePnpmDep && azureSdkForJs ? "workspace:*" : "^1.0.0";
+      packageInfo.devDependencies["@azure-tools/test-utils-vitest"] = shouldUsePnpmDep && azureSdkForJs ? "workspace:^" : "^1.0.0";
     }
     packageInfo.devDependencies["@types/node"] = shouldUsePnpmDep && azureSdkForJs ? "catalog:" : "^18.0.0";
     packageInfo.devDependencies["@vitest/browser"] = shouldUsePnpmDep && azureSdkForJs ? "catalog:testing" : "^3.0.9";

--- a/packages/rlc-common/src/metadata/buildPackageFile.ts
+++ b/packages/rlc-common/src/metadata/buildPackageFile.ts
@@ -114,11 +114,11 @@ export function updatePackageFile(
       // TODO remove model.options?.shouldUsePnpmDep after pnpm migration
       "@azure/core-lro":
         model.options?.shouldUsePnpmDep && model.options.azureSdkForJs
-          ? "workspace:*"
+          ? "workspace:^"
           : "^3.1.0",
       "@azure/abort-controller":
         model.options?.shouldUsePnpmDep && model.options.azureSdkForJs
-          ? "workspace:*"
+          ? "workspace:^"
           : "^2.1.2"
     };
   }

--- a/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
@@ -39,17 +39,17 @@ export function getAzureMonorepoDependencies(config: AzureMonorepoInfoConfig) {
 
   const runtimeDeps = {
     ...dependencies,
-    "@azure-rest/core-client": !shouldUsePnpmDep ? "^2.1.0" : "workspace:*",
+    "@azure-rest/core-client": !shouldUsePnpmDep ? "^2.1.0" : "workspace:^",
     ...(hasLro && {
-      "@azure/abort-controller": !shouldUsePnpmDep ? "^2.1.2" : "workspace:*"
+      "@azure/abort-controller": !shouldUsePnpmDep ? "^2.1.2" : "workspace:^"
     }),
-    "@azure/core-auth": !shouldUsePnpmDep ? "^1.9.0" : "workspace:*",
+    "@azure/core-auth": !shouldUsePnpmDep ? "^1.9.0" : "workspace:^",
     ...(hasLro && {
-      "@azure/core-lro": !shouldUsePnpmDep ? "^3.0.0" : "workspace:*"
+      "@azure/core-lro": !shouldUsePnpmDep ? "^3.0.0" : "workspace:^"
     }),
-    "@azure/core-rest-pipeline": !shouldUsePnpmDep ? "^1.18.2" : "workspace:*",
-    "@azure/core-util": !shouldUsePnpmDep ? "^1.11.0" : "workspace:*",
-    "@azure/logger": !shouldUsePnpmDep ? "^1.1.4" : "workspace:*",
+    "@azure/core-rest-pipeline": !shouldUsePnpmDep ? "^1.18.2" : "workspace:^",
+    "@azure/core-util": !shouldUsePnpmDep ? "^1.11.0" : "workspace:^",
+    "@azure/logger": !shouldUsePnpmDep ? "^1.1.4" : "workspace:^",
     tslib: !shouldUsePnpmDep ? "^2.8.1" : "catalog:"
   };
 
@@ -73,17 +73,17 @@ export function getAzureMonorepoDependencies(config: AzureMonorepoInfoConfig) {
     devDependencies: {
       "@azure-tools/test-credential": !shouldUsePnpmDep
         ? "^2.0.0"
-        : "workspace:*",
+        : "workspace:^",
       "@azure-tools/test-recorder": !shouldUsePnpmDep
         ? "^4.1.0"
-        : "workspace:*",
+        : "workspace:^",
       "@azure-tools/test-utils-vitest": !shouldUsePnpmDep
         ? "^1.0.0"
-        : "workspace:*",
-      "@azure/dev-tool": !shouldUsePnpmDep ? "^1.0.0" : "workspace:*",
+        : "workspace:^",
+      "@azure/dev-tool": !shouldUsePnpmDep ? "^1.0.0" : "workspace:^",
       "@azure/eslint-plugin-azure-sdk": !shouldUsePnpmDep
         ? "^3.0.0"
-        : "workspace:*",
+        : "workspace:^",
       "@azure/identity": !shouldUsePnpmDep ? "^4.6.0" : "catalog:internal",
       "@types/node": !shouldUsePnpmDep ? "^18.0.0" : "catalog:",
       eslint: !shouldUsePnpmDep ? "^9.9.0" : "catalog:",


### PR DESCRIPTION
as we should use caret versions for dependencies on our @azure packages