### PR TITLE
Use prettier-vscode extension as the default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typespec]": {
+    "editor.defaultFormatter": "typespec.typespec-vscode"
   }
 }


### PR DESCRIPTION
prettier-vscode is our recommended formatter.