### PR TITLE
Fix compile issues if upgrade tcgc to 0.63.1

### DIFF
--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -258,7 +258,10 @@ export async function $onEmit(context: EmitContext) {
     for (const client of clients) {
       const rlcModels = await transformRLCModel(client, dpgContext);
       rlcCodeModels.push(rlcModels);
-      serviceNameToRlcModelsMap.set(client.service.name, rlcModels);
+      const serviceName = Array.isArray(client.service)
+        ? (client.service[0]?.name ?? "Unknown")
+        : client.service.name;
+      serviceNameToRlcModelsMap.set(serviceName, rlcModels);
       needUnexpectedHelper.set(
         getClientName(rlcModels),
         hasUnexpectedHelper(rlcModels)

--- a/packages/typespec-ts/src/utils/clientUtils.ts
+++ b/packages/typespec-ts/src/utils/clientUtils.ts
@@ -20,7 +20,14 @@ import { NameType, normalizeName } from "@azure-tools/rlc-common";
 
 export function getRLCClients(dpgContext: SdkContext): SdkClient[] {
   const services = new Set<Namespace>();
-  listClients(dpgContext).forEach((c) => services.add(c.service));
+  listClients(dpgContext).forEach((c) => {
+    const clientService = c.service;
+    if (Array.isArray(clientService)) {
+      clientService.forEach((ns) => services.add(ns));
+    } else {
+      services.add(clientService);
+    }
+  });
   const rawServiceNamespaces = listAllServiceNamespaces(dpgContext);
   if (services.size === 0 && rawServiceNamespaces.length > 0) {
     // If no clients are found, fall back to raw service namespaces
@@ -45,7 +52,10 @@ export function getRLCClients(dpgContext: SdkContext): SdkClient[] {
 
 export function listOperationsUnderRLCClient(client: SdkClient): Operation[] {
   const operations = [];
-  const queue: (Namespace | Interface)[] = [client.service];
+  const serviceArray = Array.isArray(client.service)
+    ? client.service
+    : [client.service];
+  const queue: (Namespace | Interface)[] = [...serviceArray];
   while (queue.length > 0) {
     const current = queue.shift()!;
     if (
@@ -55,7 +65,7 @@ export function listOperationsUnderRLCClient(client: SdkClient): Operation[] {
           getNamespaceFullName(d.definition?.namespace) ===
             "Azure.ClientGenerator.Core"
       ) &&
-      current !== client.service
+      !serviceArray.includes(current as Namespace)
     ) {
       continue;
     }


### PR DESCRIPTION
The type of sdkClient.service is changed from `Namespace` to `Namespace | Namespace[]` in tcgc 0.63.1. Update the related code in JS emitter to accept an array to fix the compile issues.