### PR TITLE
Fix Nightly CI

### DIFF
--- a/packages/autorest.typescript/CHANGELOG.md
+++ b/packages/autorest.typescript/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 6.0.55 (2026-01-05)
+## 6.0.55 (2026-01-16)
 
+- [Feature] Bump TypeSpec dependencies to latest stable (1.8.0). Please refer to [#3681](https://github.com/Azure/autorest.typescript/pull/3681)
+- [Bugfix] Fix nightly CI. Please refer to [#3677](https://github.com/Azure/autorest.typescript/pull/3677)
 - [Feature] Implement array encoding for model properties. Please refer to [#3659](https://github.com/Azure/autorest.typescript/pull/3659)
 - [Feature] Add code owner. Please refer to [#3667](https://github.com/Azure/autorest.typescript/pull/3667)
 - [Feature] Upgrade tcgc for multiple service. Please refer to [#3658](https://github.com/Azure/autorest.typescript/pull/3658)

--- a/packages/rlc-common/CHANGELOG.md
+++ b/packages/rlc-common/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.48.0 (2026-01-05)
+## 0.48.0 (2026-01-16)
 
+- [Feature] Bump TypeSpec dependencies to latest stable (1.8.0). Please refer to [#3681](https://github.com/Azure/autorest.typescript/pull/3681)
+- [Bugfix] Fix nightly CI. Please refer to [#3677](https://github.com/Azure/autorest.typescript/pull/3677)
 - [Feature] Implement array encoding for model properties. Please refer to [#3659](https://github.com/Azure/autorest.typescript/pull/3659)
 - [Feature] Add code owner. Please refer to [#3667](https://github.com/Azure/autorest.typescript/pull/3667)
 - [Feature] Upgrade tcgc for multiple service. Please refer to [#3658](https://github.com/Azure/autorest.typescript/pull/3658)

--- a/packages/typespec-ts/CHANGELOG.md
+++ b/packages/typespec-ts/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 0.48.0 (2026-01-05)
+## 0.48.0 (2026-01-16)
 
+- [Feature] Bump TypeSpec dependencies to latest stable (1.8.0). Please refer to [#3681](https://github.com/Azure/autorest.typescript/pull/3681)
+- [Bugfix] Fix nightly CI. Please refer to [#3677](https://github.com/Azure/autorest.typescript/pull/3677)
 - [Feature] Implement array encoding for model properties. Please refer to [#3659](https://github.com/Azure/autorest.typescript/pull/3659)
 - [Feature] Add code owner. Please refer to [#3667](https://github.com/Azure/autorest.typescript/pull/3667)
 - [Feature] Upgrade tcgc for multiple service. Please refer to [#3658](https://github.com/Azure/autorest.typescript/pull/3658)


### PR DESCRIPTION
nightly ci error log: https://dev.azure.com/azure-sdk/public/_build/results?buildId=5757166&view=logs&j=d0d2a462-287f-51d5-e186-98b6b49f577f&t=9812ddb4-30f9-5fb0-8a89-333f2d283401

``` src/utils/clientUtils.ts(37,3): error TS2322: Type '{ kind: "SdkClient"; name: string; service: Namespace; type: Namespace; arm: boolean; crossLanguageDefinitionId: string; subOperationGroups: never[]; }[]' is not assignable to type 'SdkClient[]'.
@azure-tools/typespec-ts:build:   Property 'services' is missing in type '{ kind: "SdkClient"; name: string; service: Namespace; type: Namespace; arm: boolean; crossLanguageDefinitionId: string; subOperationGroups: never[]; }' but required in type 'SdkClient'.
@azure-tools/typespec-ts:build:  ELIFECYCLE  Command failed with exit code 2.

```