### PR TITLE
update AAD Token link reference in readme generation

### DIFF
--- a/packages/autorest.typescript/src/generators/static/hlcREADME.md.hbs
+++ b/packages/autorest.typescript/src/generators/static/hlcREADME.md.hbs
@@ -49,7 +49,7 @@ npm install {{ clientPackageName }}
 To create a client object to access the {{ serviceName }} API, you will need the `endpoint` of your {{ serviceName }} resource and a `credential`. The {{ clientDescriptiveName }} can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your {{ serviceName }} resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 

--- a/packages/autorest.typescript/test/unit/generators/static/files/case-hlcReadme-without-subid.md
+++ b/packages/autorest.typescript/test/unit/generators/static/files/case-hlcReadme-without-subid.md
@@ -35,7 +35,7 @@ npm install @azure/arm-kusto
 To create a client object to access the Azure KustoManagement API, you will need the `endpoint` of your Azure KustoManagement resource and a `credential`. The Azure KustoManagement client can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your Azure KustoManagement resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 

--- a/packages/autorest.typescript/test/unit/generators/static/files/case-hlcReadme.md
+++ b/packages/autorest.typescript/test/unit/generators/static/files/case-hlcReadme.md
@@ -35,7 +35,7 @@ npm install @azure/arm-kusto
 To create a client object to access the Azure KustoManagement API, you will need the `endpoint` of your Azure KustoManagement resource and a `credential`. The Azure KustoManagement client can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your Azure KustoManagement resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 

--- a/packages/rlc-common/src/metadata/buildReadmeFile.ts
+++ b/packages/rlc-common/src/metadata/buildReadmeFile.ts
@@ -137,7 +137,7 @@ npm install {{ clientPackageName }}
 To create a client object to access the {{ serviceName }} API, you will need the \`endpoint\` of your {{ serviceName }} resource and a \`credential\`. The {{ clientDescriptiveName }} can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your {{ serviceName }} resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the \`@azure/identity\` package:
 

--- a/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/sdk/test/arm-test/README.md
+++ b/packages/typespec-test/test/NetworkAnalytics.Management/generated/typespec-ts/sdk/test/arm-test/README.md
@@ -37,7 +37,7 @@ npm install @azure/arm-networkanalytics
 To create a client object to access the Azure MicrosoftNetworkAnalytics API, you will need the `endpoint` of your Azure MicrosoftNetworkAnalytics resource and a `credential`. The Azure MicrosoftNetworkAnalytics client can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your Azure MicrosoftNetworkAnalytics resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 

--- a/packages/typespec-test/test/ai/generated/typespec-ts/README.md
+++ b/packages/typespec-test/test/ai/generated/typespec-ts/README.md
@@ -35,7 +35,7 @@ npm install @azure/ai-client
 To create a client object to access the Azure AIProject API, you will need the `endpoint` of your Azure AIProject resource and a `credential`. The Azure AIProject client can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your Azure AIProject resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/README.md
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/README.md
@@ -35,7 +35,7 @@ npm install @azure-rest/batch
 To create a client object to access the Azure Batch API, you will need the `endpoint` of your Azure Batch resource and a `credential`. The Azure Batch client can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your Azure Batch resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 

--- a/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/README.md
+++ b/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/README.md
@@ -35,7 +35,7 @@ npm install @azure/ai-chat-protocol
 To create a client object to access the Azure ChatProtocol API, you will need the `endpoint` of your Azure ChatProtocol resource and a `credential`. The Azure ChatProtocol client can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your Azure ChatProtocol resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 

--- a/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/README.md
+++ b/packages/typespec-test/test/contentsafety_modular/generated/typespec-ts/README.md
@@ -35,7 +35,7 @@ npm install @azure-rest/ai-content-safety
 To create a client object to access the Azure ContentSafety API, you will need the `endpoint` of your Azure ContentSafety resource and a `credential`. The Azure ContentSafety client can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your Azure ContentSafety resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 

--- a/packages/typespec-test/test/healthInsights_radiologyinsights/generated/typespec-ts/README.md
+++ b/packages/typespec-test/test/healthInsights_radiologyinsights/generated/typespec-ts/README.md
@@ -35,7 +35,7 @@ npm install @azure-rest/health-insights-radiologyinsights
 To create a client object to access the Azure RadiologyInsights API, you will need the `endpoint` of your Azure RadiologyInsights resource and a `credential`. The Azure RadiologyInsights client can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your Azure RadiologyInsights resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/README.md
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/README.md
@@ -35,7 +35,7 @@ npm install @azure/load-testing
 To create a client object to access the Azure TestProfileRun API, you will need the `endpoint` of your Azure TestProfileRun resource and a `credential`. The Azure TestProfileRun client can use Azure Active Directory credentials to authenticate.
 You can find the endpoint for your Azure TestProfileRun resource in the [Azure Portal][azure_portal].
 
-You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
+You can authenticate with Azure Active Directory using a credential from the [@azure/identity][azure_identity] library or [an existing AAD Token](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token).
 
 To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
 


### PR DESCRIPTION
use `https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token`
instead of `https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token`
in readme generation