### PR TITLE
Fix override optionality: derive parameter access from method parameter

### DIFF
--- a/packages/typespec-ts/src/modular/helpers/operationHelpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/operationHelpers.ts
@@ -1542,7 +1542,8 @@ function buildHeaderParameter(
   optionalParamName: string = "options"
 ): string {
   const paramName = param.name;
-  if (!param.optional && isTypeNullable(param.type) === true) {
+  const effectiveOptional = getEffectiveOptional(param);
+  if (!effectiveOptional && isTypeNullable(param.type) === true) {
     reportDiagnostic(program, {
       code: "nullable-required-header",
       target: NoTarget
@@ -1550,7 +1551,7 @@ function buildHeaderParameter(
     return paramMap;
   }
   const conditions = [];
-  if (param.optional) {
+  if (effectiveOptional) {
     conditions.push(`${optionalParamName}?.${paramName} !== undefined`);
   }
   if (isTypeNullable(param.type) === true) {
@@ -1782,8 +1783,34 @@ function getContentTypeValue(
   }
 }
 
+/**
+ * Gets the effective optionality for an HTTP parameter by checking
+ * the linked method parameter via methodParameterSegments.
+ * This is needed because @@override can change a method parameter's
+ * optionality without updating the HTTP parameter's optional flag.
+ * For client-level parameters (onClient), preserve the HTTP parameter's own flag.
+ */
+function getEffectiveOptional(param: SdkHttpParameter): boolean {
+  // For client-level parameters, the HTTP parameter's optional flag is authoritative
+  if (param.onClient) {
+    return Boolean(param.optional);
+  }
+  // For method-level parameters with a direct mapping to a single method param,
+  // use the method parameter's optional flag (correctly reflects @@override changes)
+  if (
+    param.methodParameterSegments?.length === 1 &&
+    param.methodParameterSegments[0]?.length === 1
+  ) {
+    const methodParam = param.methodParameterSegments[0]![0];
+    if (methodParam) {
+      return Boolean(methodParam.optional);
+    }
+  }
+  return Boolean(param.optional);
+}
+
 function isRequired(param: SdkHttpParameter) {
-  return !param.optional;
+  return !getEffectiveOptional(param);
 }
 
 function getRequired(
@@ -1823,7 +1850,7 @@ function isConstant(param: SdkType): param is SdkConstantType {
 }
 
 function isOptional(param: SdkHttpParameter) {
-  return Boolean(param.optional);
+  return getEffectiveOptional(param);
 }
 
 function getOptional(

--- a/packages/typespec-ts/test/modularUnit/scenarios/operations/override.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/operations/override.md
@@ -347,3 +347,124 @@ export async function removeOptionalOriginal(
   return _removeOptionalOriginalDeserialize(result);
 }
 ```
+
+# Should handle optionality change from required to optional when using @@override
+
+Tests that when @@override changes a required header/query parameter to optional, the generated code accesses
+the parameter from the options bag instead of as a positional argument.
+
+## TypeSpec
+
+```tsp
+import "@typespec/http";
+import "@azure-tools/typespec-client-generator-core";
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+@service(#{
+  title: "Override Service"
+})
+namespace Override;
+
+// Original operation with required header and query parameters
+@route("/change-optionality/{param1}")
+@get
+op changeOptionalityOriginal(
+  @path param1: string,
+  @header requiredHeader: string,
+  @query requiredQuery: string,
+): void;
+
+// Override operation changes required header and query to optional
+op changeOptionalityCustomized(
+  @path param1: string,
+  @header requiredHeader?: string,
+  @query requiredQuery?: string,
+): void;
+
+@@override(Override.changeOptionalityOriginal, Override.changeOptionalityCustomized);
+```
+
+The config would be like:
+
+```yaml
+needTCGC: true
+needAzureCore: true
+withRawContent: true
+```
+
+## Models with Options
+
+The options interface should include the now-optional parameters:
+
+```ts models:withOptions
+import { OperationOptions } from "@azure-rest/core-client";
+
+/** Optional parameters. */
+export interface ChangeOptionalityOriginalOptionalParams extends OperationOptions {
+  requiredHeader?: string;
+  requiredQuery?: string;
+}
+```
+
+## Operations
+
+```ts operations
+import { OverrideContext as Client } from "./index.js";
+import { expandUrlTemplate } from "../static-helpers/urlTemplate.js";
+import { ChangeOptionalityOriginalOptionalParams } from "./options.js";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+
+export function _changeOptionalityOriginalSend(
+  context: Client,
+  param1: string,
+  options: ChangeOptionalityOriginalOptionalParams = { requestOptions: {} },
+): StreamableMethod {
+  const path = expandUrlTemplate(
+    "/change-optionality/{param1}{?requiredQuery}",
+    {
+      param1: param1,
+      requiredQuery: options?.requiredQuery,
+    },
+    {
+      allowReserved: options?.requestOptions?.skipUrlEncoding,
+    },
+  );
+  return context
+    .path(path)
+    .get({
+      ...operationOptionsToRequestParameters(options),
+      headers: {
+        ...(options?.requiredHeader !== undefined
+          ? { "required-header": options?.requiredHeader }
+          : {}),
+        ...options.requestOptions?.headers,
+      },
+    });
+}
+
+export async function _changeOptionalityOriginalDeserialize(
+  result: PathUncheckedResponse,
+): Promise<void> {
+  const expectedStatuses = ["204"];
+  if (!expectedStatuses.includes(result.status)) {
+    throw createRestError(result);
+  }
+
+  return;
+}
+
+export async function changeOptionalityOriginal(
+  context: Client,
+  param1: string,
+  options: ChangeOptionalityOriginalOptionalParams = { requestOptions: {} },
+): Promise<void> {
+  const result = await _changeOptionalityOriginalSend(context, param1, options);
+  return _changeOptionalityOriginalDeserialize(result);
+}
+```


### PR DESCRIPTION
## Problem

   When `@@override` changes a parameter from required to optional, the modular emitter still generates positional references (`paramName`) instead of options-bag access (`options?.paramName`). This happens because:

   - **Signature generation** uses `operation.parameters` (method-level, correctly reflects `@@override`)
   - **Request serialization** uses `operation.operation.parameters` (HTTP-level) and checks `SdkHttpParameter.optional`, which may not reflect override changes

   ## Root cause

   `getPathParameters()` already handles this correctly — it dereferences `methodParameterSegments[0][0]` to get the method parameter and uses its `optional` flag. But `getHeaderAndBodyParameters()` and `getQueryParameters()` pass the raw HTTP
  parameter to `getParameterMap()`, which checks `param.optional` on the HTTP parameter directly.

   ## Fix

   Introduced `getEffectiveOptional()` in `operationHelpers.ts` that resolves the method parameter via `methodParameterSegments` and uses its `optional` flag — following the same pattern `getPathParameters()` already uses. Client-level parameters
  (`onClient`) are excluded and continue to use the HTTP parameter's own flag.

   Updated:
   - `isOptional()` / `isRequired()` to use `getEffectiveOptional()`
   - `buildHeaderParameter()` to use `getEffectiveOptional()` for conditional spread decisions

   ## Testing

   - Added regression scenario in `override.md` where `@@override` changes a required header+query to optional
   - All 547 modular unit tests pass ✅
   - All 309 RLC unit tests pass ✅
   - Build, format, and lint all clean ✅

   ## Changes

   | File | Change |
   |------|--------|
   | `packages/typespec-ts/src/modular/helpers/operationHelpers.ts` | Added `getEffectiveOptional()`, updated `isOptional`, `isRequired`, `buildHeaderParameter` |
   | `packages/typespec-ts/test/modularUnit/scenarios/operations/override.md` | Added regression scenario for required→optional override |