### PR TITLE
feat(warp): add moduleType: commonjs to CJS target in warp.config.yml

### DIFF
--- a/packages/autorest.typescript/test/integration/generated/appconfiguration/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/appconfiguration/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/appconfigurationexport/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/appconfigurationexport/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/arrayConstraints/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/arrayConstraints/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/attestation/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/attestation/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/azureReport/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/azureReport/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyArray/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyArray/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyBoolean/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyBoolean/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyByte/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyByte/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyComplex/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplex/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyDate/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyDate/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTime/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTime/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyDictionary/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyDictionary/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyDuration/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyDuration/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyFile/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyFile/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyFormData/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyFormData/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyInteger/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyInteger/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyNumber/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyNumber/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyString/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyString/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/bodyTime/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/bodyTime/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/constantParam/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/constantParam/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/corecompattest/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/corecompattest/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/customUrl/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/customUrl/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/customUrlPaging/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/customUrlPaging/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/datafactory/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/datafactory/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/datalakestorage/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/datalakestorage/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/domainservices/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/domainservices/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/extensibleEnums/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/extensibleEnums/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/header/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/header/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/headerprefix/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/headerprefix/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/httpInfrastructure/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/httpInfrastructure/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/iotspaces/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/iotspaces/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/licenseHeader/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/licenseHeader/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/lro/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/lro/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/mapperrequired/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/mapperrequired/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/mediaTypes/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypes/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/modelFlattening/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/modelFlattening/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/multipleInheritance/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/multipleInheritance/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/nameChecker/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/nameChecker/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/noLicenseHeader/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/noLicenseHeader/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/noMappers/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/noMappers/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/noOperation/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/noOperation/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/nonStringEnum/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/nonStringEnum/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/objectType/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/objectType/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/odataDiscriminator/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/odataDiscriminator/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/operationgroupclash/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/operationgroupclash/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/optionalnull/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/optionalnull/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/paging/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/paging/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/pagingNoIterators/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/pagingNoIterators/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/petstore/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/petstore/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/readmeFileChecker/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/readmeFileChecker/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/regexConstraint/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/regexConstraint/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/report/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/report/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/requiredOptional/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/requiredOptional/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/resources/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/resources/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/sealedchoice/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/sealedchoice/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/storageblob/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/storageblob/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/storagefileshare/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/storagefileshare/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/textanalytics/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/textanalytics/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/url/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/url/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/url2/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/url2/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/urlMulti/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/urlMulti/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev1/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev1/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev2/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev2/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/uuid/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/uuid/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/validation/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/validation/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/xmlservice/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/xmlservice/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/warp.config.yml
+++ b/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/warp.config.yml
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/warp.config.yml
@@ -20,3 +20,4 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs

--- a/packages/rlc-common/src/metadata/buildWarpConfig.ts
+++ b/packages/rlc-common/src/metadata/buildWarpConfig.ts
@@ -30,6 +30,7 @@ targets:
   - name: commonjs
     condition: require
     tsconfig: "../../../tsconfig.src.cjs.json"
+    moduleType: commonjs
 `;
 
 /**


### PR DESCRIPTION
## Summary

The warp build tool in `azure-sdk-for-js` now supports an explicit `moduleType` field on targets in `warp.config.yml`. When a CJS target declares `moduleType: commonjs` and its program identity (excluding moduleType) matches an already-emitted ESM target, warp skips running tsc entirely and transforms the ESM output to CJS via esbuild instead. This dramatically speeds up CJS compilation.

## Changes

- **Template** (`packages/rlc-common/src/metadata/buildWarpConfig.ts`): Added `moduleType: commonjs` to the CJS target in `WarpConfigTemplate`
- **Test fixtures** (81 files): Updated all generated `warp.config.yml` files to include the new field

## Related

- azure-sdk-for-js PR: https://github.com/Azure/azure-sdk-for-js/pull/37893