### PR TITLE
Fix arm resource model property filtering for specific cases

### DIFF
--- a/packages/typespec-test/test/compute/generated/typespec-ts/review/compute.api.md
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/review/compute.api.md
@@ -59,6 +59,7 @@ export class ComputeClient {
     readonly pipeline: Pipeline;
     readonly restorePointCollections: RestorePointCollectionsOperations;
     readonly virtualMachines: VirtualMachinesOperations;
+    readonly virtualMachineScaleSetExtensions: VirtualMachineScaleSetExtensionsOperations;
 }
 
 // @public
@@ -277,6 +278,11 @@ export interface RestorePollerOptions<TResult, TResponse extends PathUncheckedRe
 }
 
 // @public
+export interface SubResourceReadOnly {
+    readonly id?: string;
+}
+
+// @public
 export interface SystemData {
     createdAt?: Date;
     createdBy?: string;
@@ -301,6 +307,34 @@ export interface VirtualMachine extends TrackedResource {
 export interface VirtualMachineProperties {
     // (undocumented)
     readonly provisioningState?: ResourceProvisioningState;
+}
+
+// @public
+export interface VirtualMachineScaleSetExtension extends SubResourceReadOnly {
+    name?: string;
+    properties?: VirtualMachineScaleSetExtensionProperties;
+    readonly vmType?: string;
+}
+
+// @public
+export interface VirtualMachineScaleSetExtensionProperties {
+    forceUpdateTag?: string;
+}
+
+// @public
+export interface VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams extends OperationOptions {
+    updateIntervalInMs?: number;
+}
+
+// @public
+export interface VirtualMachineScaleSetExtensionsGetOptionalParams extends OperationOptions {
+    expand?: string;
+}
+
+// @public
+export interface VirtualMachineScaleSetExtensionsOperations {
+    createOrUpdate: (resourceGroupName: string, vmssExtensionName: string, resource: VirtualMachineScaleSetExtension, options?: VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams) => PollerLike<OperationState<VirtualMachineScaleSetExtension>, VirtualMachineScaleSetExtension>;
+    get: (resourceGroupName: string, vmssExtensionName: string, options?: VirtualMachineScaleSetExtensionsGetOptionalParams) => Promise<VirtualMachineScaleSetExtension>;
 }
 
 // @public

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/api/virtualMachineScaleSetExtensions/index.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/api/virtualMachineScaleSetExtensions/index.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export { createOrUpdate, get } from "./operations.js";
+export type {
+  VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams,
+  VirtualMachineScaleSetExtensionsGetOptionalParams,
+} from "./options.js";

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/api/virtualMachineScaleSetExtensions/operations.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/api/virtualMachineScaleSetExtensions/operations.ts
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ComputeContext as Client } from "../index.js";
+import {
+  VirtualMachineScaleSetExtension,
+  virtualMachineScaleSetExtensionSerializer,
+  virtualMachineScaleSetExtensionDeserializer,
+} from "../../models/compute/models.js";
+import { errorResponseDeserializer } from "../../models/models.js";
+import { getLongRunningPoller } from "../../static-helpers/pollingHelpers.js";
+import { expandUrlTemplate } from "../../static-helpers/urlTemplate.js";
+import {
+  VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams,
+  VirtualMachineScaleSetExtensionsGetOptionalParams,
+} from "./options.js";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import { PollerLike, OperationState } from "@azure/core-lro";
+
+export function _createOrUpdateSend(
+  context: Client,
+  resourceGroupName: string,
+  vmssExtensionName: string,
+  resource: VirtualMachineScaleSetExtension,
+  options: VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams = { requestOptions: {} },
+): StreamableMethod {
+  const path = expandUrlTemplate(
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/extensions/{vmssExtensionName}{?api%2Dversion}",
+    {
+      subscriptionId: context.subscriptionId,
+      resourceGroupName: resourceGroupName,
+      vmssExtensionName: vmssExtensionName,
+      "api%2Dversion": "2025-04-01",
+    },
+    {
+      allowReserved: options?.requestOptions?.skipUrlEncoding,
+    },
+  );
+  return context
+    .path(path)
+    .put({
+      ...operationOptionsToRequestParameters(options),
+      contentType: "application/json",
+      headers: { accept: "application/json", ...options.requestOptions?.headers },
+      body: virtualMachineScaleSetExtensionSerializer(resource),
+    });
+}
+
+export async function _createOrUpdateDeserialize(
+  result: PathUncheckedResponse,
+): Promise<VirtualMachineScaleSetExtension> {
+  const expectedStatuses = ["200", "201", "202"];
+  if (!expectedStatuses.includes(result.status)) {
+    const error = createRestError(result);
+    error.details = errorResponseDeserializer(result.body);
+
+    throw error;
+  }
+
+  return virtualMachineScaleSetExtensionDeserializer(result.body);
+}
+
+/** The operation to create or update an extension. */
+export function createOrUpdate(
+  context: Client,
+  resourceGroupName: string,
+  vmssExtensionName: string,
+  resource: VirtualMachineScaleSetExtension,
+  options: VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams = { requestOptions: {} },
+): PollerLike<OperationState<VirtualMachineScaleSetExtension>, VirtualMachineScaleSetExtension> {
+  return getLongRunningPoller(context, _createOrUpdateDeserialize, ["200", "201", "202"], {
+    updateIntervalInMs: options?.updateIntervalInMs,
+    abortSignal: options?.abortSignal,
+    getInitialResponse: () =>
+      _createOrUpdateSend(context, resourceGroupName, vmssExtensionName, resource, options),
+    resourceLocationConfig: "location",
+    apiVersion: "2025-04-01",
+  }) as PollerLike<
+    OperationState<VirtualMachineScaleSetExtension>,
+    VirtualMachineScaleSetExtension
+  >;
+}
+
+export function _getSend(
+  context: Client,
+  resourceGroupName: string,
+  vmssExtensionName: string,
+  options: VirtualMachineScaleSetExtensionsGetOptionalParams = { requestOptions: {} },
+): StreamableMethod {
+  const path = expandUrlTemplate(
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/extensions/{vmssExtensionName}{?api%2Dversion,%24expand}",
+    {
+      subscriptionId: context.subscriptionId,
+      resourceGroupName: resourceGroupName,
+      vmssExtensionName: vmssExtensionName,
+      "api%2Dversion": "2025-04-01",
+      "%24expand": options?.expand,
+    },
+    {
+      allowReserved: options?.requestOptions?.skipUrlEncoding,
+    },
+  );
+  return context
+    .path(path)
+    .get({
+      ...operationOptionsToRequestParameters(options),
+      headers: { accept: "application/json", ...options.requestOptions?.headers },
+    });
+}
+
+export async function _getDeserialize(
+  result: PathUncheckedResponse,
+): Promise<VirtualMachineScaleSetExtension> {
+  const expectedStatuses = ["200"];
+  if (!expectedStatuses.includes(result.status)) {
+    const error = createRestError(result);
+    error.details = errorResponseDeserializer(result.body);
+
+    throw error;
+  }
+
+  return virtualMachineScaleSetExtensionDeserializer(result.body);
+}
+
+/** The operation to get the extension. */
+export async function get(
+  context: Client,
+  resourceGroupName: string,
+  vmssExtensionName: string,
+  options: VirtualMachineScaleSetExtensionsGetOptionalParams = { requestOptions: {} },
+): Promise<VirtualMachineScaleSetExtension> {
+  const result = await _getSend(context, resourceGroupName, vmssExtensionName, options);
+  return _getDeserialize(result);
+}

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/api/virtualMachineScaleSetExtensions/options.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/api/virtualMachineScaleSetExtensions/options.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { OperationOptions } from "@azure-rest/core-client";
+
+/** Optional parameters. */
+export interface VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams extends OperationOptions {
+  /** Delay to wait until next poll, in milliseconds. */
+  updateIntervalInMs?: number;
+}
+
+/** Optional parameters. */
+export interface VirtualMachineScaleSetExtensionsGetOptionalParams extends OperationOptions {
+  /** The expand expression to apply on the operation. */
+  expand?: string;
+}

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/classic/index.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/classic/index.ts
@@ -6,3 +6,4 @@ export type { DiskAccessesOperations } from "./diskAccesses/index.js";
 export type { DisksOperations } from "./disks/index.js";
 export type { RestorePointCollectionsOperations } from "./restorePointCollections/index.js";
 export type { VirtualMachinesOperations } from "./virtualMachines/index.js";
+export type { VirtualMachineScaleSetExtensionsOperations } from "./virtualMachineScaleSetExtensions/index.js";

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/classic/virtualMachineScaleSetExtensions/index.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/classic/virtualMachineScaleSetExtensions/index.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ComputeContext } from "../../api/computeContext.js";
+import { createOrUpdate, get } from "../../api/virtualMachineScaleSetExtensions/operations.js";
+import {
+  VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams,
+  VirtualMachineScaleSetExtensionsGetOptionalParams,
+} from "../../api/virtualMachineScaleSetExtensions/options.js";
+import { VirtualMachineScaleSetExtension } from "../../models/compute/models.js";
+import { PollerLike, OperationState } from "@azure/core-lro";
+
+/** Interface representing a VirtualMachineScaleSetExtensions operations. */
+export interface VirtualMachineScaleSetExtensionsOperations {
+  /** The operation to create or update an extension. */
+  createOrUpdate: (
+    resourceGroupName: string,
+    vmssExtensionName: string,
+    resource: VirtualMachineScaleSetExtension,
+    options?: VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams,
+  ) => PollerLike<OperationState<VirtualMachineScaleSetExtension>, VirtualMachineScaleSetExtension>;
+  /** The operation to get the extension. */
+  get: (
+    resourceGroupName: string,
+    vmssExtensionName: string,
+    options?: VirtualMachineScaleSetExtensionsGetOptionalParams,
+  ) => Promise<VirtualMachineScaleSetExtension>;
+}
+
+function _getVirtualMachineScaleSetExtensions(context: ComputeContext) {
+  return {
+    createOrUpdate: (
+      resourceGroupName: string,
+      vmssExtensionName: string,
+      resource: VirtualMachineScaleSetExtension,
+      options?: VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams,
+    ) => createOrUpdate(context, resourceGroupName, vmssExtensionName, resource, options),
+    get: (
+      resourceGroupName: string,
+      vmssExtensionName: string,
+      options?: VirtualMachineScaleSetExtensionsGetOptionalParams,
+    ) => get(context, resourceGroupName, vmssExtensionName, options),
+  };
+}
+
+export function _getVirtualMachineScaleSetExtensionsOperations(
+  context: ComputeContext,
+): VirtualMachineScaleSetExtensionsOperations {
+  return {
+    ..._getVirtualMachineScaleSetExtensions(context),
+  };
+}

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/computeClient.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/computeClient.ts
@@ -16,6 +16,10 @@ import {
   _getRestorePointCollectionsOperations,
 } from "./classic/restorePointCollections/index.js";
 import {
+  VirtualMachineScaleSetExtensionsOperations,
+  _getVirtualMachineScaleSetExtensionsOperations,
+} from "./classic/virtualMachineScaleSetExtensions/index.js";
+import {
   VirtualMachinesOperations,
   _getVirtualMachinesOperations,
 } from "./classic/virtualMachines/index.js";
@@ -46,6 +50,9 @@ export class ComputeClient {
     this.pipeline = this._client.pipeline;
     this.diskAccesses = _getDiskAccessesOperations(this._client);
     this.disks = _getDisksOperations(this._client);
+    this.virtualMachineScaleSetExtensions = _getVirtualMachineScaleSetExtensionsOperations(
+      this._client,
+    );
     this.actionGroups = _getActionGroupsOperations(this._client);
     this.restorePointCollections = _getRestorePointCollectionsOperations(this._client);
     this.virtualMachines = _getVirtualMachinesOperations(this._client);
@@ -55,6 +62,8 @@ export class ComputeClient {
   public readonly diskAccesses: DiskAccessesOperations;
   /** The operation groups for disks */
   public readonly disks: DisksOperations;
+  /** The operation groups for virtualMachineScaleSetExtensions */
+  public readonly virtualMachineScaleSetExtensions: VirtualMachineScaleSetExtensionsOperations;
   /** The operation groups for actionGroups */
   public readonly actionGroups: ActionGroupsOperations;
   /** The operation groups for restorePointCollections */

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/index.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/index.ts
@@ -40,6 +40,9 @@ export type {
   RestorePointCollectionProperties,
   ComputeActionGroup,
   ComputeActionGroupsProperties,
+  VirtualMachineScaleSetExtension,
+  VirtualMachineScaleSetExtensionProperties,
+  SubResourceReadOnly,
 } from "./models/compute/index.js";
 export type {
   ComputeDiskActionGroup,
@@ -71,11 +74,16 @@ export type {
   VirtualMachinesGetOptionalParams,
 } from "./api/virtualMachines/index.js";
 export type {
+  VirtualMachineScaleSetExtensionsCreateOrUpdateOptionalParams,
+  VirtualMachineScaleSetExtensionsGetOptionalParams,
+} from "./api/virtualMachineScaleSetExtensions/index.js";
+export type {
   ActionGroupsOperations,
   DiskAccessesOperations,
   DisksOperations,
   RestorePointCollectionsOperations,
   VirtualMachinesOperations,
+  VirtualMachineScaleSetExtensionsOperations,
 } from "./classic/index.js";
 export type { PageSettings, ContinuablePage, PagedAsyncIterableIterator };
 export { AzureClouds };

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/models/compute/index.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/models/compute/index.ts
@@ -8,4 +8,7 @@ export type {
   RestorePointCollectionProperties,
   ComputeActionGroup,
   ComputeActionGroupsProperties,
+  VirtualMachineScaleSetExtension,
+  VirtualMachineScaleSetExtensionProperties,
+  SubResourceReadOnly,
 } from "./models.js";

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/models/compute/models.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/models/compute/models.ts
@@ -151,3 +151,73 @@ export function computeActionGroupsPropertiesDeserializer(
     provisioningState: item["provisioningState"],
   };
 }
+
+/** Describes a Virtual Machine Scale Set Extension. */
+export interface VirtualMachineScaleSetExtension extends SubResourceReadOnly {
+  /** The resource-specific properties for this resource. */
+  properties?: VirtualMachineScaleSetExtensionProperties;
+  /** Resource type */
+  readonly vmType?: string;
+  /** Resource name */
+  name?: string;
+}
+
+export function virtualMachineScaleSetExtensionSerializer(
+  item: VirtualMachineScaleSetExtension,
+): any {
+  return {
+    properties: !item["properties"]
+      ? item["properties"]
+      : virtualMachineScaleSetExtensionPropertiesSerializer(item["properties"]),
+    name: item["name"],
+  };
+}
+
+export function virtualMachineScaleSetExtensionDeserializer(
+  item: any,
+): VirtualMachineScaleSetExtension {
+  return {
+    id: item["id"],
+    properties: !item["properties"]
+      ? item["properties"]
+      : virtualMachineScaleSetExtensionPropertiesDeserializer(item["properties"]),
+    vmType: item["type"],
+    name: item["name"],
+  };
+}
+
+/** Describes the properties of a Virtual Machine Scale Set Extension. */
+export interface VirtualMachineScaleSetExtensionProperties {
+  /** If a value is provided and is different from the previous value, the extension handler will be forced to update even if the extension configuration has not changed. */
+  forceUpdateTag?: string;
+}
+
+export function virtualMachineScaleSetExtensionPropertiesSerializer(
+  item: VirtualMachineScaleSetExtensionProperties,
+): any {
+  return { forceUpdateTag: item["forceUpdateTag"] };
+}
+
+export function virtualMachineScaleSetExtensionPropertiesDeserializer(
+  item: any,
+): VirtualMachineScaleSetExtensionProperties {
+  return {
+    forceUpdateTag: item["forceUpdateTag"],
+  };
+}
+
+/** model interface SubResourceReadOnly */
+export interface SubResourceReadOnly {
+  /** Resource Id */
+  readonly id?: string;
+}
+
+export function subResourceReadOnlySerializer(_item: SubResourceReadOnly): any {
+  return {};
+}
+
+export function subResourceReadOnlyDeserializer(item: any): SubResourceReadOnly {
+  return {
+    id: item["id"],
+  };
+}

--- a/packages/typespec-test/test/compute/generated/typespec-ts/src/restorePollerHelpers.ts
+++ b/packages/typespec-test/test/compute/generated/typespec-ts/src/restorePollerHelpers.ts
@@ -4,6 +4,7 @@
 import { ComputeClient } from "./computeClient.js";
 import { _createOrUpdateDeserialize } from "./api/diskAccesses/operations.js";
 import { _createOrUpdateDeserialize as _createOrUpdateDeserializeDisks } from "./api/disks/operations.js";
+import { _createOrUpdateDeserialize as _createOrUpdateDeserializeVirtualMachineScaleSetExtensions } from "./api/virtualMachineScaleSetExtensions/operations.js";
 import { _createOrUpdateDeserialize as _createOrUpdateDeserializeVirtualMachines } from "./api/virtualMachines/operations.js";
 import { getLongRunningPoller } from "./static-helpers/pollingHelpers.js";
 import { OperationOptions, PathUncheckedResponse } from "@azure-rest/core-client";
@@ -84,6 +85,11 @@ const deserializeMap: Record<string, DeserializationHelper> = {
     { deserializer: _createOrUpdateDeserialize, expectedStatuses: ["200", "202", "201"] },
   "PUT /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}":
     { deserializer: _createOrUpdateDeserializeDisks, expectedStatuses: ["200", "201", "202"] },
+  "PUT /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/extensions/{vmssExtensionName}":
+    {
+      deserializer: _createOrUpdateDeserializeVirtualMachineScaleSetExtensions,
+      expectedStatuses: ["200", "201", "202"],
+    },
   "PUT /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}":
     {
       deserializer: _createOrUpdateDeserializeVirtualMachines,

--- a/packages/typespec-test/test/compute/spec/compute.tsp
+++ b/packages/typespec-test/test/compute/spec/compute.tsp
@@ -135,3 +135,95 @@ interface ActionGroups {
         }
     >;
 }
+
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+model SubResourceReadOnly {
+    /**
+     * Resource Id
+     */
+    @visibility(Lifecycle.Read)
+    id?: Azure.Core.armResourceIdentifier;
+}
+
+#suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "For backward compatibility"
+@doc("Concrete proxy resource types can be created by aliasing this type using a specific property type.")
+@Http.Private.includeInapplicableMetadataInPayload(false)
+@Azure.ResourceManager.Legacy.customAzureResource
+model ProxySubResourceReadOnly<Properties extends {}>
+    extends SubResourceReadOnly {
+    @doc("The resource-specific properties for this resource.")
+    properties?: Properties;
+
+    /**
+     * The name of the parent resource.
+     */
+    @path
+    @visibility(Lifecycle.Read)
+    @segment("parents")
+    parentName: string;
+}
+
+/**
+ * Describes a Virtual Machine Scale Set Extension.
+ */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-custom-resource-usage-discourage" "For backward compatibility"
+model VirtualMachineScaleSetExtension
+    is ProxySubResourceReadOnly<VirtualMachineScaleSetExtensionProperties> {
+    /**
+     * Resource type
+     */
+    @visibility(Lifecycle.Read)
+    @encodedName("application/json", "type")
+    vmType?: string;
+
+    /**
+     * Resource name
+     */
+    name?: string;
+
+    /**
+     * The name of the VM scale set extension.
+     */
+    @path
+    @visibility(Lifecycle.Read)
+    @segment("extensions")
+    @key("vmssExtensionName")
+    vmssExtensionName: string;
+}
+
+/**
+ * Describes the properties of a Virtual Machine Scale Set Extension.
+ */
+model VirtualMachineScaleSetExtensionProperties {
+    /**
+     * If a value is provided and is different from the previous value, the extension handler will be forced to update even if the extension configuration has not changed.
+     */
+    forceUpdateTag?: string;
+}
+
+@armResourceOperations
+interface VirtualMachineScaleSetExtensions {
+    /**
+     * The operation to get the extension.
+     */
+    get is ArmResourceRead<
+        VirtualMachineScaleSetExtension,
+        Parameters = {
+            /**
+             * The expand expression to apply on the operation.
+             */
+            @query("$expand")
+            $expand?: string;
+        }
+    >;
+
+    /**
+     * The operation to create or update an extension.
+     */
+    createOrUpdate is ArmResourceCreateOrReplaceAsync<
+        VirtualMachineScaleSetExtension,
+        LroHeaders = ArmLroLocationHeader<FinalResult = VirtualMachineScaleSetExtension> &
+            Azure.Core.Foundations.RetryAfterHeader
+    >;
+}

--- a/packages/typespec-ts/src/modular/emitModels.ts
+++ b/packages/typespec-ts/src/modular/emitModels.ts
@@ -33,6 +33,7 @@ import {
   isReadOnly,
   listAllServiceNamespaces
 } from "@azure-tools/typespec-client-generator-core";
+// import { isKey } from "@typespec/compiler";
 import {
   getExternalModel,
   getModelExpression,
@@ -59,7 +60,7 @@ import {
 import path from "path";
 import { refkey } from "../framework/refkey.js";
 import { useContext } from "../contextManager.js";
-import { isMetadata, isOrExtendsHttpFile } from "@typespec/http";
+import { isMetadata, isOrExtendsHttpFile, Visibility } from "@typespec/http";
 import { isAzureCoreErrorType } from "../utils/modelUtils.js";
 import { getHeaderClientOptions } from "./helpers/clientOptionHelpers.js";
 import { isExtensibleEnum } from "./type-expressions/get-enum-expression.js";
@@ -736,7 +737,6 @@ function buildModelInterface(
   // properties (@header, @query, @path) since they are deserialized separately.
   // For input models, keep metadata properties — users need to pass them.
   const hasInputUsage = (type.usage & UsageFlags.Input) === UsageFlags.Input;
-  const isArmResource = isArmResourceModel(type);
   const interfaceStructure = {
     kind: StructureKind.Interface,
     name: normalizeModelName(context, type, NameType.Interface, true),
@@ -746,15 +746,8 @@ function buildModelInterface(
         if (!hasInputUsage && p.__raw && isMetadata(context.program, p.__raw)) {
           return false;
         }
-        // Skip the "name" metadata property on ARM resource models.
-        // ARM resource "name" is a @path property inherited from the base Resource type
-        // and is handled by the ARM infrastructure, not set by the user directly.
-        if (
-          isArmResource &&
-          p.name === "name" &&
-          p.__raw &&
-          isMetadata(context.program, p.__raw)
-        ) {
+        // Skip required metadata properties with Read visibility for ARM as they are not intended to be in the model
+        if (context.arm && p.__raw && isMetadata(context.program, p.__raw) && !p.optional && p.visibility?.includes(Visibility.Read)) {
           return false;
         }
         // filter out the flatten property to be processed later
@@ -948,20 +941,6 @@ export function normalizeModelName(
   const internalModelPrefix =
     isPagedResultModel(context, type) || type.isGeneratedName ? "_" : "";
   return `${internalModelPrefix}${normalizeName(namespacePrefix + type.name, nameType, true)}${unionSuffix}`;
-}
-
-/**
- * Checks if a model descends from the ARM common-types Resource base type
- * (TrackedResource, ProxyResource, etc.) by walking the ancestor chain.
- */
-function isArmResourceModel(type: SdkModelType): boolean {
-  const ancestors = getAllAncestors(type);
-  return ancestors.some(
-    (ancestor) =>
-      ancestor.kind === "model" &&
-      ancestor.crossLanguageDefinitionId ===
-        "Azure.ResourceManager.CommonTypes.Resource"
-  );
 }
 
 function buildModelPolymorphicType(context: SdkContext, type: SdkModelType) {

--- a/packages/typespec-ts/src/modular/emitModels.ts
+++ b/packages/typespec-ts/src/modular/emitModels.ts
@@ -747,11 +747,11 @@ function buildModelInterface(
           return false;
         }
         // Skip required metadata properties with Read visibility for ARM as they are not intended to be in the model
+        // These properties are not be generated no matter they are in input or output models in most cases in HLC
         if (
           context.arm &&
           p.__raw &&
           isMetadata(context.program, p.__raw) &&
-          !p.optional &&
           p.visibility?.includes(Visibility.Read)
         ) {
           return false;

--- a/packages/typespec-ts/src/modular/emitModels.ts
+++ b/packages/typespec-ts/src/modular/emitModels.ts
@@ -747,7 +747,13 @@ function buildModelInterface(
           return false;
         }
         // Skip required metadata properties with Read visibility for ARM as they are not intended to be in the model
-        if (context.arm && p.__raw && isMetadata(context.program, p.__raw) && !p.optional && p.visibility?.includes(Visibility.Read)) {
+        if (
+          context.arm &&
+          p.__raw &&
+          isMetadata(context.program, p.__raw) &&
+          !p.optional &&
+          p.visibility?.includes(Visibility.Read)
+        ) {
           return false;
         }
         // filter out the flatten property to be processed later


### PR DESCRIPTION
See issue description in #3910.

To fix the gap of `@Http.Private.includeInapplicableMetadataInPayload(false)` and `@key` handling in TypeSpec for ARM resource models after supporting generating metadata parameters in models (#3848 ), the workaround here is to filter out metadata properties that are **required** and has **visibility.read** for ARM.