### PR TITLE
fix: keep paged result model public when used in non-paging operations

### DIFF
--- a/packages/typespec-ts/src/framework/hooks/sdkTypes.ts
+++ b/packages/typespec-ts/src/framework/hooks/sdkTypes.ts
@@ -23,6 +23,11 @@ import { NameType, normalizeName } from "@azure-tools/rlc-common";
 export const emitQueue: Set<SdkType> = new Set<SdkType>();
 export const flattenPropertyModelMap: Map<SdkModelPropertyType, SdkModelType> =
   new Map<SdkModelPropertyType, SdkModelType>();
+/**
+ * Set of paged result models that are also used in non-paging operations.
+ * Precomputed during visitPackageTypes for O(1) lookups in normalizeModelName.
+ */
+export const pagedModelsUsedInNonPagingOps = new Set<SdkType>();
 
 export interface SdkTypeContext {
   operations: Map<Type, SdkServiceMethod<SdkHttpOperation>>;

--- a/packages/typespec-ts/src/modular/emitModels.ts
+++ b/packages/typespec-ts/src/modular/emitModels.ts
@@ -78,7 +78,8 @@ import {
 import {
   emitQueue,
   flattenPropertyModelMap,
-  getAllOperationsFromClient
+  getAllOperationsFromClient,
+  pagedModelsUsedInNonPagingOps
 } from "../framework/hooks/sdkTypes.js";
 import {
   getAllAncestors,
@@ -945,7 +946,11 @@ export function normalizeModelName(
     ? segments.join("")
     : "";
   const internalModelPrefix =
-    isPagedResultModel(context, type) || type.isGeneratedName ? "_" : "";
+    (isPagedResultModel(context, type) &&
+      !pagedModelsUsedInNonPagingOps.has(type)) ||
+    type.isGeneratedName
+      ? "_"
+      : "";
   return `${internalModelPrefix}${normalizeName(namespacePrefix + type.name, nameType, true)}${unionSuffix}`;
 }
 
@@ -1038,6 +1043,7 @@ export function visitPackageTypes(context: SdkContext) {
   const { sdkPackage } = context;
   emitQueue.clear();
   flattenPropertyModelMap.clear();
+  pagedModelsUsedInNonPagingOps.clear();
   // Add all models in the package to the emit queue
   for (const model of sdkPackage.models) {
     visitType(context, model);
@@ -1119,6 +1125,22 @@ function visitMethod(
     visitType(context, parameter.type);
   });
   visitType(context, method.response.type);
+  trackPagedModelInNonPagingMethod(context, method);
+}
+
+/**
+ * If a non-paging method's direct response type is a paged result model,
+ * mark it so that normalizeModelName keeps it public (no "_" prefix).
+ */
+function trackPagedModelInNonPagingMethod(
+  context: SdkContext,
+  method: SdkServiceMethod<SdkHttpOperation>
+): void {
+  if (method.kind !== "basic" && method.kind !== "lro") return;
+  const respType = method.response.type;
+  if (respType && isPagedResultModel(context, respType)) {
+    pagedModelsUsedInNonPagingOps.add(respType);
+  }
 }
 
 function visitType(context: SdkContext, type: SdkType | undefined) {

--- a/packages/typespec-ts/test/modularUnit/scenarios/models/pagedModelInNonPagingOp.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/models/pagedModelInNonPagingOp.md
@@ -1,4 +1,4 @@
-# only: Paged result model used in both paging and non-paging operations should not have \_ prefix
+# Paged result model used in both paging and non-paging operations should not have \_ prefix
 
 ## TypeSpec
 
@@ -91,7 +91,9 @@ export interface UsageListResult {
 export function usageListResultDeserializer(item: any): UsageListResult {
   return {
     nextLink: item["nextLink"],
-    value: !item["value"] ? item["value"] : usageArrayDeserializer(item["value"]),
+    value: !item["value"]
+      ? item["value"]
+      : usageArrayDeserializer(item["value"])
   };
 }
 
@@ -108,7 +110,7 @@ export interface Usage {
 
 export function usageDeserializer(item: any): Usage {
   return {
-    test: item["test"],
+    test: item["test"]
   };
 }
 
@@ -120,7 +122,9 @@ export interface ErrorResponse {
 
 export function errorResponseDeserializer(item: any): ErrorResponse {
   return {
-    error: !item["error"] ? item["error"] : errorDetailDeserializer(item["error"]),
+    error: !item["error"]
+      ? item["error"]
+      : errorDetailDeserializer(item["error"])
   };
 }
 
@@ -143,20 +147,26 @@ export function errorDetailDeserializer(item: any): ErrorDetail {
     code: item["code"],
     message: item["message"],
     target: item["target"],
-    details: !item["details"] ? item["details"] : errorDetailArrayDeserializer(item["details"]),
+    details: !item["details"]
+      ? item["details"]
+      : errorDetailArrayDeserializer(item["details"]),
     additionalInfo: !item["additionalInfo"]
       ? item["additionalInfo"]
-      : errorAdditionalInfoArrayDeserializer(item["additionalInfo"]),
+      : errorAdditionalInfoArrayDeserializer(item["additionalInfo"])
   };
 }
 
-export function errorDetailArrayDeserializer(result: Array<ErrorDetail>): any[] {
+export function errorDetailArrayDeserializer(
+  result: Array<ErrorDetail>
+): any[] {
   return result.map((item) => {
     return errorDetailDeserializer(item);
   });
 }
 
-export function errorAdditionalInfoArrayDeserializer(result: Array<ErrorAdditionalInfo>): any[] {
+export function errorAdditionalInfoArrayDeserializer(
+  result: Array<ErrorAdditionalInfo>
+): any[] {
   return result.map((item) => {
     return errorAdditionalInfoDeserializer(item);
   });
@@ -170,16 +180,18 @@ export interface ErrorAdditionalInfo {
   readonly info?: any;
 }
 
-export function errorAdditionalInfoDeserializer(item: any): ErrorAdditionalInfo {
+export function errorAdditionalInfoDeserializer(
+  item: any
+): ErrorAdditionalInfo {
   return {
     type: item["type"],
-    info: item["info"],
+    info: item["info"]
   };
 }
 
 /** Known values of {@link Versions} that the service accepts. */
 export enum KnownVersions {
   /** 2023-12-01 */
-  V20231201 = "2023-12-01",
+  V20231201 = "2023-12-01"
 }
 ```

--- a/packages/typespec-ts/test/modularUnit/scenarios/models/pagedModelInNonPagingOp.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/models/pagedModelInNonPagingOp.md
@@ -1,0 +1,185 @@
+# only: Paged result model used in both paging and non-paging operations should not have \_ prefix
+
+## TypeSpec
+
+```tsp
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.ResourceManager;
+@armProviderNamespace
+@service
+@versioned(Versions)
+@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+namespace Microsoft.Test;
+enum Versions {
+  v2023_12_01: "2023-12-01",
+}
+model TestResource is TrackedResource<TestProperties> {
+  @key("testName")
+  @path
+  @segment("tests")
+  name: string;
+}
+model TestProperties {
+  state?: string;
+}
+
+model UsageListResult {
+  @nextLink
+  nextLink?: string;
+  @pageItems
+  value?: Usage[];
+}
+model Usage {
+  test?: string;
+}
+
+// Paging operation: uses @list so UsageListResult is treated as a paged result
+interface UsagesOperationGroup {
+  @autoRoute
+  @get
+  @action("usages")
+  @list
+  list is ArmProviderActionSync<
+    Response = UsageListResult,
+    Scope = SubscriptionActionScope,
+    Parameters = {
+      ...LocationParameter;
+    }
+  >;
+}
+
+// Non-paging operation: no @list, returns UsageListResult directly
+@armResourceOperations
+interface TestResources {
+  @action("usages")
+  listUsages is ArmResourceActionSync<
+    TestResource,
+    Request = void,
+    Response = ArmResponse<UsageListResult>,
+    BaseParameters = Azure.ResourceManager.Foundations.DefaultBaseParameters<TestResource>
+  >;
+}
+```
+
+```yaml
+withRawContent: true
+```
+
+## ts models
+
+```ts models
+/**
+ * This file contains only generated model types and their (de)serializers.
+ * Disable the following rules for internal models with '_' prefix and deserializers which require 'any' for raw JSON input.
+ */
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/** model interface UsageListResult */
+export interface UsageListResult {
+  nextLink?: string;
+  value?: Usage[];
+}
+
+export function usageListResultDeserializer(item: any): UsageListResult {
+  return {
+    nextLink: item["nextLink"],
+    value: !item["value"] ? item["value"] : usageArrayDeserializer(item["value"]),
+  };
+}
+
+export function usageArrayDeserializer(result: Array<Usage>): any[] {
+  return result.map((item) => {
+    return usageDeserializer(item);
+  });
+}
+
+/** model interface Usage */
+export interface Usage {
+  test?: string;
+}
+
+export function usageDeserializer(item: any): Usage {
+  return {
+    test: item["test"],
+  };
+}
+
+/** Common error response for all Azure Resource Manager APIs to return error details for failed operations. */
+export interface ErrorResponse {
+  /** The error object. */
+  error?: ErrorDetail;
+}
+
+export function errorResponseDeserializer(item: any): ErrorResponse {
+  return {
+    error: !item["error"] ? item["error"] : errorDetailDeserializer(item["error"]),
+  };
+}
+
+/** The error detail. */
+export interface ErrorDetail {
+  /** The error code. */
+  readonly code?: string;
+  /** The error message. */
+  readonly message?: string;
+  /** The error target. */
+  readonly target?: string;
+  /** The error details. */
+  readonly details?: ErrorDetail[];
+  /** The error additional info. */
+  readonly additionalInfo?: ErrorAdditionalInfo[];
+}
+
+export function errorDetailDeserializer(item: any): ErrorDetail {
+  return {
+    code: item["code"],
+    message: item["message"],
+    target: item["target"],
+    details: !item["details"] ? item["details"] : errorDetailArrayDeserializer(item["details"]),
+    additionalInfo: !item["additionalInfo"]
+      ? item["additionalInfo"]
+      : errorAdditionalInfoArrayDeserializer(item["additionalInfo"]),
+  };
+}
+
+export function errorDetailArrayDeserializer(result: Array<ErrorDetail>): any[] {
+  return result.map((item) => {
+    return errorDetailDeserializer(item);
+  });
+}
+
+export function errorAdditionalInfoArrayDeserializer(result: Array<ErrorAdditionalInfo>): any[] {
+  return result.map((item) => {
+    return errorAdditionalInfoDeserializer(item);
+  });
+}
+
+/** The resource management error additional info. */
+export interface ErrorAdditionalInfo {
+  /** The additional info type. */
+  readonly type?: string;
+  /** The additional info. */
+  readonly info?: any;
+}
+
+export function errorAdditionalInfoDeserializer(item: any): ErrorAdditionalInfo {
+  return {
+    type: item["type"],
+    info: item["info"],
+  };
+}
+
+/** Known values of {@link Versions} that the service accepts. */
+export enum KnownVersions {
+  /** 2023-12-01 */
+  V20231201 = "2023-12-01",
+}
+```


### PR DESCRIPTION
## Problem

When a paged result model (e.g. `UsageListResult` with `@nextLink`/`@pageItems`) is used in both a paging operation and a non-paging operation, the codegen was unconditionally prefixing it with `_` (e.g. `_UsageListResult`). The `_` prefix marks it as an internal model, making it inaccessible for non-paging operations that reference it directly.

## Fix

- Track which paged result models are referenced by non-paging (`basic`/`lro`) methods during the visit phase via a new `pagedModelsUsedInNonPagingOps` set in `sdkTypes.ts`
- In `normalizeModelName`, skip the `_` prefix for paged models that are also used in non-paging operations
- Added a `trackPagedModelInNonPagingMethod` helper called from `visitMethod`

## Changes

- `packages/typespec-ts/src/framework/hooks/sdkTypes.ts` - added `pagedModelsUsedInNonPagingOps` set
- `packages/typespec-ts/src/modular/emitModels.ts` - updated `normalizeModelName` logic and added tracking in visit phase
- `packages/typespec-ts/test/modularUnit/scenarios/models/pagedModelInNonPagingOp.md` - unit test scenario