### PR TITLE
fix: stop generating vitest.esm.config.ts

### DIFF
--- a/packages/autorest.typescript/src/generators/test/vitestGenerator.ts
+++ b/packages/autorest.typescript/src/generators/test/vitestGenerator.ts
@@ -11,16 +11,9 @@ import viteConfig from "../../../vitest.browser.shared.config.ts";
 
 export default viteConfig;`;
 
-const esmConfig = `
-import { mergeConfig } from "vitest/config";
-import vitestConfig from "./vitest.config.ts";
-import vitestEsmConfig from "../../../vitest.esm.shared.config.ts";
-
-export default mergeConfig(vitestConfig, vitestEsmConfig);`;
-
 export function generateVitestConfig(
   project: Project,
-  platform: "browser" | "node" | "esm"
+  platform: "browser" | "node"
 ) {
   const { generateTest, generateMetadata, azureSdkForJs } = getAutorestOptions();
   if (
@@ -35,13 +28,11 @@ export function generateVitestConfig(
       project.createSourceFile("vitest.browser.config.ts", browserConfig, {
         overwrite: true
       });
+      break;
     case "node":
       project.createSourceFile("vitest.config.ts", nodeConfig, {
         overwrite: true
       });
-    case "esm":
-      project.createSourceFile("vitest.esm.config.ts", esmConfig, {
-        overwrite: true
-      });
+      break;
   }
 }

--- a/packages/autorest.typescript/src/typescriptGenerator.ts
+++ b/packages/autorest.typescript/src/typescriptGenerator.ts
@@ -98,7 +98,6 @@ export async function generateTypeScriptLibrary(
     if (azureSdkForJs) {
       generateVitestConfig(project, "node");
       generateVitestConfig(project, "browser");
-      generateVitestConfig(project, "esm");
     }
   }
   generateTsConfig(project);


### PR DESCRIPTION
## Problem

The codegen still generates `vitest.esm.config.ts` files that reference `vitest.esm.shared.config.ts`, but this file was removed from azure-sdk-for-js in [PR #35660](https://github.com/Azure/azure-sdk-for-js/pull/35660).

This causes errors in newly generated packages:
```
Cannot find module '../../../vitest.esm.shared.config.ts'
```

## Solution

Remove the ESM vitest config generation:
- Delete the `esmConfig` template
- Remove `'esm'` from the `platform` union type
- Remove the `generateVitestConfig(project, 'esm')` call

## Changes

| File | Change |
|------|--------|
| `vitestGenerator.ts` | Remove `esmConfig` and `'esm'` case |
| `typescriptGenerator.ts` | Remove `generateVitestConfig(project, 'esm')` call |

Fixes Azure/azure-sdk-for-js#37275

cc @MaryGao @kazrael2119 @jeremymeng