### PR TITLE
Fix body parameter accessor to use methodParameterSegments

### DIFF
--- a/packages/autorest.typescript/CHANGELOG.md
+++ b/packages/autorest.typescript/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 6.0.70 (2026-05-13)
+## 6.0.70 (2026-05-14)
 
+- [Bugfix] Fix body parameter accessor to use methodParameterSegments. Please refer to [#3961](https://github.com/Azure/autorest.typescript/pull/3961)
 - [Feature] Bump TypeSpec dependencies to latest stable. Please refer to [#3959](https://github.com/Azure/autorest.typescript/pull/3959)
 - [Bugfix] Deduplicate statusCodes in getExpectedStatuses. Please refer to [#3956](https://github.com/Azure/autorest.typescript/pull/3956)
 - [Feature] Align Azure monorepo package.json metadata with new repository schema across codegen packages. Please refer to [#3950](https://github.com/Azure/autorest.typescript/pull/3950)

--- a/packages/rlc-common/CHANGELOG.md
+++ b/packages/rlc-common/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.53.0 (2026-05-13)
+## 0.53.0 (2026-05-14)
 
+- [Bugfix] Fix body parameter accessor to use methodParameterSegments. Please refer to [#3961](https://github.com/Azure/autorest.typescript/pull/3961)
 - [Feature] Bump TypeSpec dependencies to latest stable. Please refer to [#3959](https://github.com/Azure/autorest.typescript/pull/3959)
 - [Bugfix] Deduplicate statusCodes in getExpectedStatuses. Please refer to [#3956](https://github.com/Azure/autorest.typescript/pull/3956)
 - [Feature] Align Azure monorepo package.json metadata with new repository schema across codegen packages. Please refer to [#3950](https://github.com/Azure/autorest.typescript/pull/3950)

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/operations.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/operations.ts
@@ -1030,9 +1030,7 @@ export function _disableNodeSchedulingSend(
           : {}),
         ...options.requestOptions?.headers,
       },
-      body: !options["body"]
-        ? options["body"]
-        : nodeDisableSchedulingOptionsSerializer(options["body"]),
+      body: !options?.body ? options?.body : nodeDisableSchedulingOptionsSerializer(options?.body),
     });
 }
 
@@ -1099,7 +1097,7 @@ export function _reimageNodeSend(
           : {}),
         ...options.requestOptions?.headers,
       },
-      body: !options["body"] ? options["body"] : nodeReimageOptionsSerializer(options["body"]),
+      body: !options?.body ? options?.body : nodeReimageOptionsSerializer(options?.body),
     });
 }
 
@@ -1165,7 +1163,7 @@ export function _rebootNodeSend(
           : {}),
         ...options.requestOptions?.headers,
       },
-      body: !options["body"] ? options["body"] : nodeRebootOptionsSerializer(options["body"]),
+      body: !options?.body ? options?.body : nodeRebootOptionsSerializer(options?.body),
     });
 }
 
@@ -4001,9 +3999,7 @@ export function _terminateJobSend(
           : {}),
         ...options.requestOptions?.headers,
       },
-      body: !options["body"]
-        ? options["body"]
-        : batchJobTerminateOptionsSerializer(options["body"]),
+      body: !options?.body ? options?.body : batchJobTerminateOptionsSerializer(options?.body),
     });
 }
 

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/loadTestRun/api/operations.ts
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/src/loadTestRun/api/operations.ts
@@ -187,7 +187,7 @@ export function _listMetricsSend(
       ...operationOptionsToRequestParameters(options),
       contentType: "application/json",
       headers: { accept: "application/json", ...options.requestOptions?.headers },
-      body: !options["body"] ? options["body"] : metricRequestPayloadSerializer(options["body"]),
+      body: !options?.body ? options?.body : metricRequestPayloadSerializer(options?.body),
     });
 }
 

--- a/packages/typespec-ts/CHANGELOG.md
+++ b/packages/typespec-ts/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.53.0 (2026-05-13)
+## 0.53.0 (2026-05-14)
 
+- [Bugfix] Fix body parameter accessor to use methodParameterSegments. Please refer to [#3961](https://github.com/Azure/autorest.typescript/pull/3961)
 - [Feature] Bump TypeSpec dependencies to latest stable. Please refer to [#3959](https://github.com/Azure/autorest.typescript/pull/3959)
 - [Bugfix] Deduplicate statusCodes in getExpectedStatuses. Please refer to [#3956](https://github.com/Azure/autorest.typescript/pull/3956)
 - [Feature] Align Azure monorepo package.json metadata with new repository schema across codegen packages. Please refer to [#3950](https://github.com/Azure/autorest.typescript/pull/3950)

--- a/packages/typespec-ts/src/modular/helpers/operationHelpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/operationHelpers.ts
@@ -1702,14 +1702,7 @@ function buildBodyParameter(
     }) as string | undefined;
   }
 
-  const bodyParamName = normalizeName(
-    bodyParameter.name,
-    NameType.Parameter,
-    true
-  );
-  let bodyNameExpression = bodyParameter.optional
-    ? `${optionalParamName}["${bodyParamName}"]`
-    : bodyParamName;
+  let bodyNameExpression = getParamAccessor(bodyParameter, optionalParamName);
 
   // Check if body parameter has a client default value with matching type
   const hasClientDefault =

--- a/packages/typespec-ts/src/modular/helpers/operationHelpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/operationHelpers.ts
@@ -1716,15 +1716,17 @@ function buildBodyParameter(
     bodyNameExpression = `(${bodyNameExpression} ?? ${formattedDefault})`;
   }
 
-  // Only apply nullOrUndefinedPrefix if there's no client default value
-  // because the default value already handles null/undefined cases
-  const nullOrUndefinedPrefix = hasClientDefault
-    ? ""
-    : getPropertySerializationPrefix(
-        context,
-        bodyParameter,
-        bodyParameter.optional ? optionalParamName : undefined
-      );
+  // Build null guard using bodyNameExpression so it stays consistent with the
+  // accessor path (especially for nested body parameters like options?.body?.x).
+  // Skip when there's a client default value since it already handles null/undefined.
+  const needsNullGuard =
+    !hasClientDefault &&
+    (bodyParameter.optional ||
+      isTypeNullable(bodyParameter.type) ||
+      bodyNameExpression.includes("?."));
+  const nullOrUndefinedPrefix = needsNullGuard
+    ? `!${bodyNameExpression}? ${bodyNameExpression}:`
+    : "";
 
   // For dual-format operations, check the contentType option at runtime
   if (
@@ -2105,6 +2107,9 @@ function getParamAccessor(
   param: SdkHttpParameter,
   optionalParamName: string = "options"
 ): string {
+  if (param.isGeneratedName) {
+    return param.name;
+  }
   const methodParamExpr = getMethodParamExpr(param, optionalParamName);
   const clientPrefix = "context.";
   if (methodParamExpr) {
@@ -2132,6 +2137,11 @@ function getMethodParamExpr(
 ): string | undefined {
   const segments = param.methodParameterSegments;
   if (segments.length === 0) {
+    return undefined;
+  }
+  // When there are multiple paths (e.g., a composite body from multiple method
+  // params), we cannot resolve a single accessor — fall back to the caller's logic.
+  if (segments.length > 1) {
     return undefined;
   }
   const path = segments[0];

--- a/packages/typespec-ts/test/modularUnit/scenarios/operations/bodyParam/nestedBodyRootParam.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/operations/bodyParam/nestedBodyRootParam.md
@@ -1,0 +1,105 @@
+# Nested bodyRoot parameter should use correct accessor from methodParameterSegments
+
+Tests that when a `@bodyRoot` property is nested inside a wrapper model (e.g., as a named
+property of an anonymous model parameter), the generated code correctly accesses the body
+through the wrapper (e.g., `body.stopParameters`) instead of using the property name directly.
+
+## TypeSpec
+
+```tsp
+model StopParameters {
+  category?: string;
+  linkType?: string;
+  wasSuccessful?: boolean;
+}
+
+@route("/stop")
+@post
+op stopTest(body: {
+  @bodyRoot stopParameters: StopParameters;
+}): void;
+```
+
+## Models
+
+```ts models
+/**
+ * This file contains only generated model types and their (de)serializers.
+ * Disable the following rules for internal models with '_' prefix and deserializers which require 'any' for raw JSON input.
+ */
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/** model interface StopParameters */
+export interface StopParameters {
+  category?: string;
+  linkType?: string;
+  wasSuccessful?: boolean;
+}
+
+export function stopParametersSerializer(item: StopParameters): any {
+  return {
+    category: item["category"],
+    linkType: item["linkType"],
+    wasSuccessful: item["wasSuccessful"],
+  };
+}
+
+/** model interface _StopTestParameterBody */
+export interface _StopTestParameterBody {
+  stopParameters: StopParameters;
+}
+
+export function _stopTestParameterBodySerializer(item: _StopTestParameterBody): any {
+  return { stopParameters: stopParametersSerializer(item["stopParameters"]) };
+}
+```
+
+## Operations
+
+```ts operations
+import { TestingContext as Client } from "./index.js";
+import { StopParameters, stopParametersSerializer } from "../models/models.js";
+import { StopTestOptionalParams } from "./options.js";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+
+export function _stopTestSend(
+  context: Client,
+  body: {
+    stopParameters: StopParameters;
+  },
+  options: StopTestOptionalParams = { requestOptions: {} },
+): StreamableMethod {
+  return context
+    .path("/stop")
+    .post({
+      ...operationOptionsToRequestParameters(options),
+      contentType: "application/json",
+      body: stopParametersSerializer(body.stopParameters),
+    });
+}
+
+export async function _stopTestDeserialize(result: PathUncheckedResponse): Promise<void> {
+  const expectedStatuses = ["204"];
+  if (!expectedStatuses.includes(result.status)) {
+    throw createRestError(result);
+  }
+
+  return;
+}
+
+export async function stopTest(
+  context: Client,
+  body: {
+    stopParameters: StopParameters;
+  },
+  options: StopTestOptionalParams = { requestOptions: {} },
+): Promise<void> {
+  const result = await _stopTestSend(context, body, options);
+  return _stopTestDeserialize(result);
+}
+```

--- a/packages/typespec-ts/test/modularUnit/scenarios/operations/bodyParam/nestedBodyRootParam.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/operations/bodyParam/nestedBodyRootParam.md
@@ -103,3 +103,216 @@ export async function stopTest(
   return _stopTestDeserialize(result);
 }
 ```
+
+# Nested bodyRoot with optional wrapper should add null guard
+
+Tests that when the wrapper model parameter is optional, the generated code adds a null guard
+for the nested body accessor path (e.g., `options?.body?.stopParameters`).
+
+## TypeSpec
+
+```tsp
+model StopParameters {
+  category?: string;
+  linkType?: string;
+  wasSuccessful?: boolean;
+}
+
+@route("/stop-optional-wrapper")
+@post
+op stopOptionalWrapperTest(body?: {
+  @bodyRoot stopParameters: StopParameters;
+}): void;
+```
+
+## Operations
+
+```ts operations
+import { TestingContext as Client } from "./index.js";
+import { stopParametersSerializer } from "../models/models.js";
+import { StopOptionalWrapperTestOptionalParams } from "./options.js";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+
+export function _stopOptionalWrapperTestSend(
+  context: Client,
+  options: StopOptionalWrapperTestOptionalParams = { requestOptions: {} },
+): StreamableMethod {
+  return context
+    .path("/stop-optional-wrapper")
+    .post({
+      ...operationOptionsToRequestParameters(options),
+      contentType: "application/json",
+      body: !options?.body?.stopParameters
+        ? options?.body?.stopParameters
+        : stopParametersSerializer(options?.body?.stopParameters),
+    });
+}
+
+export async function _stopOptionalWrapperTestDeserialize(
+  result: PathUncheckedResponse,
+): Promise<void> {
+  const expectedStatuses = ["204"];
+  if (!expectedStatuses.includes(result.status)) {
+    throw createRestError(result);
+  }
+
+  return;
+}
+
+export async function stopOptionalWrapperTest(
+  context: Client,
+  options: StopOptionalWrapperTestOptionalParams = { requestOptions: {} },
+): Promise<void> {
+  const result = await _stopOptionalWrapperTestSend(context, options);
+  return _stopOptionalWrapperTestDeserialize(result);
+}
+```
+
+# Nested bodyRoot with optional property should add null guard
+
+Tests that when the `@bodyRoot` property itself is optional within a required wrapper,
+the generated code adds a null guard for the optional body parameter.
+
+## TypeSpec
+
+```tsp
+model StopParameters {
+  category?: string;
+  linkType?: string;
+  wasSuccessful?: boolean;
+}
+
+@route("/stop-optional-prop")
+@post
+op stopOptionalPropTest(body: {
+  @bodyRoot stopParameters?: StopParameters;
+}): void;
+```
+
+## Operations
+
+```ts operations
+import { TestingContext as Client } from "./index.js";
+import { StopParameters, stopParametersSerializer } from "../models/models.js";
+import { StopOptionalPropTestOptionalParams } from "./options.js";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+
+export function _stopOptionalPropTestSend(
+  context: Client,
+  body: {
+    stopParameters?: StopParameters;
+  },
+  options: StopOptionalPropTestOptionalParams = { requestOptions: {} },
+): StreamableMethod {
+  return context
+    .path("/stop-optional-prop")
+    .post({
+      ...operationOptionsToRequestParameters(options),
+      contentType: "application/json",
+      body: !body.stopParameters
+        ? body.stopParameters
+        : stopParametersSerializer(body.stopParameters),
+    });
+}
+
+export async function _stopOptionalPropTestDeserialize(
+  result: PathUncheckedResponse,
+): Promise<void> {
+  const expectedStatuses = ["204"];
+  if (!expectedStatuses.includes(result.status)) {
+    throw createRestError(result);
+  }
+
+  return;
+}
+
+export async function stopOptionalPropTest(
+  context: Client,
+  body: {
+    stopParameters?: StopParameters;
+  },
+  options: StopOptionalPropTestOptionalParams = { requestOptions: {} },
+): Promise<void> {
+  const result = await _stopOptionalPropTestSend(context, body, options);
+  return _stopOptionalPropTestDeserialize(result);
+}
+```
+
+# Nested bodyRoot with both optional wrapper and optional property
+
+Tests that when both the wrapper model parameter and the `@bodyRoot` property are optional,
+the generated code adds a null guard with full optional chaining.
+
+## TypeSpec
+
+```tsp
+model StopParameters {
+  category?: string;
+  linkType?: string;
+  wasSuccessful?: boolean;
+}
+
+@route("/stop-both-optional")
+@post
+op stopBothOptionalTest(body?: {
+  @bodyRoot stopParameters?: StopParameters;
+}): void;
+```
+
+## Operations
+
+```ts operations
+import { TestingContext as Client } from "./index.js";
+import { stopParametersSerializer } from "../models/models.js";
+import { StopBothOptionalTestOptionalParams } from "./options.js";
+import {
+  StreamableMethod,
+  PathUncheckedResponse,
+  createRestError,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+
+export function _stopBothOptionalTestSend(
+  context: Client,
+  options: StopBothOptionalTestOptionalParams = { requestOptions: {} },
+): StreamableMethod {
+  return context
+    .path("/stop-both-optional")
+    .post({
+      ...operationOptionsToRequestParameters(options),
+      contentType: "application/json",
+      body: !options?.body?.stopParameters
+        ? options?.body?.stopParameters
+        : stopParametersSerializer(options?.body?.stopParameters),
+    });
+}
+
+export async function _stopBothOptionalTestDeserialize(
+  result: PathUncheckedResponse,
+): Promise<void> {
+  const expectedStatuses = ["204"];
+  if (!expectedStatuses.includes(result.status)) {
+    throw createRestError(result);
+  }
+
+  return;
+}
+
+export async function stopBothOptionalTest(
+  context: Client,
+  options: StopBothOptionalTestOptionalParams = { requestOptions: {} },
+): Promise<void> {
+  const result = await _stopBothOptionalTestSend(context, options);
+  return _stopBothOptionalTestDeserialize(result);
+}
+```

--- a/packages/typespec-ts/test/modularUnit/scenarios/operations/bodyParam/optionalConstantBodyParam.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/operations/bodyParam/optionalConstantBodyParam.md
@@ -28,7 +28,7 @@ export function _readSend(
     .post({
       ...operationOptionsToRequestParameters(options),
       contentType: "text/plain",
-      body: !options["parameters"] ? options["parameters"] : "constantBody",
+      body: !options?.parameters ? options?.parameters : "constantBody",
     });
 }
 

--- a/packages/typespec-ts/test/modularUnit/scenarios/operations/clientDefaultValue.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/operations/clientDefaultValue.md
@@ -79,7 +79,7 @@ export function _createSend(
       ...operationOptionsToRequestParameters(options),
       contentType: "text/plain",
       headers: { accept: "text/plain", ...options.requestOptions?.headers },
-      body: options["body"] ?? "default-body",
+      body: options?.body ?? "default-body",
     });
 }
 

--- a/packages/typespec-ts/test/modularUnit/scenarios/operations/operations.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/operations/operations.md
@@ -328,7 +328,7 @@ export function _readSend(
     .post({
       ...operationOptionsToRequestParameters(options),
       contentType: "application/json",
-      body: !options["bars"] ? options["bars"] : barArraySerializer(options["bars"]),
+      body: !options?.bars ? options?.bars : barArraySerializer(options?.bars),
     });
 }
 
@@ -506,7 +506,7 @@ export function _readSend(
       ...operationOptionsToRequestParameters(options),
       contentType: "application/json",
       headers: { accept: "application/json", ...options.requestOptions?.headers },
-      body: !options["bars"] ? options["bars"] : barArraySerializer(options["bars"]),
+      body: !options?.bars ? options?.bars : barArraySerializer(options?.bars),
     });
 }
 
@@ -683,7 +683,7 @@ needAzureCore: true
 
 ```ts operations
 import { TestingContext as Client } from "./index.js";
-import { _Bar, _barDeserializer, errorDeserializer} from "../models/models.js";
+import { _Bar, _barDeserializer, errorDeserializer } from "../models/models.js";
 import {
   PagedAsyncIterableIterator,
   buildPagedAsyncIterator,

--- a/packages/typespec-ts/test/modularUnit/scenarios/samples/parameters/bodyOptionalCheck.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/samples/parameters/bodyOptionalCheck.md
@@ -108,7 +108,7 @@ export function _readSend(
       ...operationOptionsToRequestParameters(options),
       contentType: "application/json",
       headers: { accept: "application/json", ...options.requestOptions?.headers },
-      body: !options["widget"] ? options["widget"] : bodyParameterSerializer(options["widget"]),
+      body: !options?.widget ? options?.widget : bodyParameterSerializer(options?.widget),
     });
 }
 

--- a/packages/typespec-ts/test/modularUnit/scenarios/samples/parameters/bodyOptionalParameterName.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/samples/parameters/bodyOptionalParameterName.md
@@ -181,9 +181,9 @@ export function _backupSend(
       ...operationOptionsToRequestParameters(options),
       contentType: "application/json",
       headers: { accept: "application/json", ...options.requestOptions?.headers },
-      body: !options["backupRequestProperties"]
-        ? options["backupRequestProperties"]
-        : backupRequestPropertiesSerializer(options["backupRequestProperties"]),
+      body: !options?.backupRequestProperties
+        ? options?.backupRequestProperties
+        : backupRequestPropertiesSerializer(options?.backupRequestProperties),
     });
 }
 

--- a/packages/typespec-ts/test/modularUnit/scenarios/samples/parameters/parameterNormalization.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/samples/parameters/parameterNormalization.md
@@ -80,9 +80,9 @@ export function _postSend(
         ...(options?.headerParam !== undefined ? { header_param: options?.headerParam } : {}),
         ...options.requestOptions?.headers,
       },
-      body: !options["listCredentialsRequest"]
-        ? options["listCredentialsRequest"]
-        : listCredentialsRequestSerializer(options["listCredentialsRequest"]),
+      body: !options?.listCredentialsRequest
+        ? options?.listCredentialsRequest
+        : listCredentialsRequestSerializer(options?.listCredentialsRequest),
     });
 }
 


### PR DESCRIPTION
## Problem

When a body parameter is nested inside a wrapper model, the generated serializer uses the bare property name instead of the correct accessor path. For example, given the following TypeSpec:

```
op stopTest(body: {
  @bodyRoot stopParameters: StopParameters;
}): void;
```

The generated code produces:

```typescript
// incorrect - references a variable that doesn't exist
body: stopParametersSerializer(stopParameters)
```

instead of:

```typescript
// correct - accesses the property through the wrapper
body: stopParametersSerializer(body.stopParameters)
```

This causes TypeScript compilation errors in the generated code.

## Fix

In `buildBodyParameter()`, replaced the direct `bodyParameter.name` lookup with `getParamAccessor()`, which resolves the accessor expression from `methodParameterSegments` -- consistent with how header and query parameters already work.

## Testing

Added unit test `nestedBodyRootParam.md` that verifies nested `@bodyRoot` parameters generate the correct accessor path through the wrapper object.