### PR TITLE
[typespec-ts] Fix missing config/ tsconfig files when updating existing packages

### DIFF
--- a/packages/rlc-common/test/integration/warpConfig.spec.ts
+++ b/packages/rlc-common/test/integration/warpConfig.spec.ts
@@ -4,6 +4,12 @@
 import { describe, it, expect } from "vitest";
 
 import { buildWarpConfig } from "../../src/metadata/buildWarpConfig.js";
+import {
+  buildTsSrcEsmConfig,
+  buildTsSrcBrowserConfig,
+  buildTsSrcReactNativeConfig,
+  buildTsSrcCjsConfig
+} from "../../src/metadata/buildTsConfig.js";
 import { createMockModel } from "./mockHelper.js";
 
 describe("warp.config.yml generation", () => {
@@ -125,6 +131,30 @@ describe("warp.config.yml generation", () => {
       expect(result!.content).toContain("name: react-native");
       expect(result!.content).toContain("name: esm");
       expect(result!.content).toContain("name: commonjs");
+    });
+  });
+
+  describe("tsconfig path consistency", () => {
+    it("warp config references every config/ tsconfig that the builders produce", () => {
+      const model = createMockModel({
+        moduleKind: "esm",
+        isMonorepo: true,
+        flavor: "azure"
+      });
+
+      const warpContent = buildWarpConfig(model)!.content;
+
+      const configBuilders = [
+        buildTsSrcEsmConfig,
+        buildTsSrcBrowserConfig,
+        buildTsSrcReactNativeConfig,
+        buildTsSrcCjsConfig
+      ];
+
+      for (const builder of configBuilders) {
+        const tsconfigPath = `./${builder().path}`;
+        expect(warpContent).toContain(tsconfigPath);
+      }
     });
   });
 });

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -640,11 +640,16 @@ export async function $onEmit(context: EmitContext) {
         );
       }
 
-      // Update warp.config.yml for Azure monorepo packages
+      // Update warp.config.yml and config/ tsconfig files for Azure monorepo packages
       if (option.azureSdkForJs) {
         updateBuilders.push((model: RLCModel) =>
           buildWarpConfig(model, modularPackageInfo)
         );
+        updateBuilders.push(buildTsConfig);
+        updateBuilders.push(buildTsSrcEsmConfig);
+        updateBuilders.push(buildTsSrcBrowserConfig);
+        updateBuilders.push(buildTsSrcReactNativeConfig);
+        updateBuilders.push(buildTsSrcCjsConfig);
       }
 
       // If the client name changed, regenerate the README and snippets completely;


### PR DESCRIPTION
## Problem

Since the 0.53.0 release (which included #3938), SDK Validation is broken for all TypeSpec-based PRs in azure-rest-api-specs. The error looks like:

```
[warp] Invalid config in warp.config.yml: target "browser" references tsconfig
"./config/tsconfig.src.browser.json" which does not exist at
.../azure-sdk-for-js/sdk/cognitiveservices/arm-cognitiveservices/config/tsconfig.src.browser.json
```

## Root Cause

There are two code paths in `packages/typespec-ts/src/index.ts` for metadata generation:

1. **New package** (`shouldGenerateMetadata = true`) — generates `warp.config.yml` AND the `config/` tsconfig files ✅
2. **Update existing package** (`shouldGenerateMetadata = false`, i.e. `package.json` already exists and `generate-metadata` is not explicitly `true`) — generates `warp.config.yml` but **not** the `config/` tsconfig files or `tsconfig.json` ❌

SDK automation always hits path (2) since the packages already exist in azure-sdk-for-js. So `warp.config.yml` gets written with `./config/tsconfig.src.browser.json` references, but the `config/` directory is never created. Maybe it assumes all existing packages in the repo would have been migrated already but that ended up not being the case?

## Fix

I added the missing `buildTsConfig`, `buildTsSrcEsmConfig`, `buildTsSrcBrowserConfig`, `buildTsSrcReactNativeConfig`, and `buildTsSrcCjsConfig` builders to the update path, matching what the new-package path already does. Also added a consistency test to make sure every tsconfig path referenced in `warp.config.yml` has a corresponding builder.

## Validation

I repro'd the bug e2e with a minimal ARM TypeSpec spec with `azure-sdk-for-js: true` and a pre-existing `package.json` (to trigger the update path), then verified the fix by applying the same process:


**Before fix:**
| File | Status |
|------|--------|
| `warp.config.yml` | ✅ Generated (references `./config/tsconfig.src.*.json`) |
| `config/tsconfig.src.browser.json` | ❌ Missing |
| `config/tsconfig.src.esm.json` | ❌ Missing |
| `config/tsconfig.src.cjs.json` | ❌ Missing |
| `config/tsconfig.src.react-native.json` | ❌ Missing |
| `tsconfig.json` | ❌ Not updated |

**After fix:**
| File | Status |
|------|--------|
| `warp.config.yml` | ✅ Generated |
| `config/tsconfig.src.browser.json` | ✅ Generated |
| `config/tsconfig.src.esm.json` | ✅ Generated |
| `config/tsconfig.src.cjs.json` | ✅ Generated |
| `config/tsconfig.src.react-native.json` | ✅ Generated |
| `tsconfig.json` | ✅ Updated with `./config/` references |

All existing tests pass (rlc-common 103/103, typespec-ts unit tests unchanged). I also confirmed the autorest.typescript generator does not have this issue — it uses a single linear code path with no new/update split.