### PR TITLE
Fix sample generation for nested @bodyRoot parameters

### DIFF
--- a/packages/typespec-ts/src/modular/emitSamples.ts
+++ b/packages/typespec-ts/src/modular/emitSamples.ts
@@ -466,15 +466,47 @@ function prepareExampleParameters(
         );
       }
     } else {
-      result.push(
-        prepareExampleValue(
-          dpgContext,
-          bodyParam.name,
-          bodyExample.value,
-          bodyParam.optional,
-          bodyParam.onClient
-        )
-      );
+      // Check if the body parameter is nested inside a wrapper (e.g., @bodyRoot)
+      const segments = bodyParam.methodParameterSegments;
+      const isNestedBody =
+        segments.length === 1 &&
+        segments[0] !== undefined &&
+        segments[0].length > 1;
+      if (isNestedBody) {
+        const path = segments[0]!;
+        // The first segment is the method-level wrapper param (e.g., "body")
+        const methodParamName = path[0]!.name;
+        const methodParamOptional = path[0]!.optional;
+        // Wrap the example value with the intermediate property names
+        let wrappedValue = getParameterValue(dpgContext, bodyExample.value);
+        for (let i = path.length - 1; i >= 1; i--) {
+          const propName = normalizeName(
+            path[i]!.name,
+            NameType.Property,
+            true
+          );
+          wrappedValue = `{ ${propName}: ${wrappedValue} }`;
+        }
+        result.push(
+          prepareExampleValue(
+            dpgContext,
+            methodParamName,
+            wrappedValue,
+            methodParamOptional,
+            bodyParam.onClient
+          )
+        );
+      } else {
+        result.push(
+          prepareExampleValue(
+            dpgContext,
+            bodyParam.name,
+            bodyExample.value,
+            bodyParam.optional,
+            bodyParam.onClient
+          )
+        );
+      }
     }
   }
   // optional parameters

--- a/packages/typespec-ts/src/modular/helpers/exampleValueHelpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/exampleValueHelpers.ts
@@ -494,14 +494,44 @@ export function prepareCommonParameters(
         );
       }
     } else {
-      result.push(
-        prepareCommonValue(
-          bodyParam.name,
-          bodyExample.value,
-          bodyParam.optional,
-          bodyParam.onClient
-        )
-      );
+      // Check if the body parameter is nested inside a wrapper (e.g., @bodyRoot)
+      const segments = bodyParam.methodParameterSegments;
+      const isNestedBody =
+        segments.length === 1 &&
+        segments[0] !== undefined &&
+        segments[0].length > 1;
+      if (isNestedBody) {
+        const path = segments[0]!;
+        // The first segment is the method-level wrapper param (e.g., "body")
+        const methodParamName = path[0]!.name;
+        const methodParamOptional = path[0]!.optional;
+        // Wrap the example value with the intermediate property names
+        let wrappedValue = serializeExampleValue(bodyExample.value);
+        for (let i = path.length - 1; i >= 1; i--) {
+          const propName = normalizeName(
+            path[i]!.name,
+            NameType.Property
+          );
+          wrappedValue = `{ ${propName}: ${wrappedValue} }`;
+        }
+        result.push(
+          prepareCommonValue(
+            methodParamName,
+            wrappedValue,
+            methodParamOptional,
+            bodyParam.onClient
+          )
+        );
+      } else {
+        result.push(
+          prepareCommonValue(
+            bodyParam.name,
+            bodyExample.value,
+            bodyParam.optional,
+            bodyParam.onClient
+          )
+        );
+      }
     }
   }
 

--- a/packages/typespec-ts/src/modular/helpers/exampleValueHelpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/exampleValueHelpers.ts
@@ -508,10 +508,7 @@ export function prepareCommonParameters(
         // Wrap the example value with the intermediate property names
         let wrappedValue = serializeExampleValue(bodyExample.value);
         for (let i = path.length - 1; i >= 1; i--) {
-          const propName = normalizeName(
-            path[i]!.name,
-            NameType.Property
-          );
+          const propName = normalizeName(path[i]!.name, NameType.Property);
           wrappedValue = `{ ${propName}: ${wrappedValue} }`;
         }
         result.push(

--- a/packages/typespec-ts/test/modularUnit/scenarios/samples/parameters/nestedBodyRootParam.md
+++ b/packages/typespec-ts/test/modularUnit/scenarios/samples/parameters/nestedBodyRootParam.md
@@ -1,0 +1,74 @@
+# Should generate correct sample for nested @bodyRoot parameter
+
+When a body parameter uses `@bodyRoot` nested inside a wrapper, the sample should
+use the wrapper parameter name and nest the body value inside the property structure.
+
+## TypeSpec
+
+This is tsp definition.
+
+```tsp
+@doc("Request parameters for stop action.")
+model StopParameters {
+  @doc("The link index.")
+  linkIndex: string;
+  @doc("The category.")
+  category: string;
+}
+
+@doc("Stop with nested body root.")
+op stop(@path name: string, body: { @bodyRoot stopParameters: StopParameters }): {
+  @body body: {};
+};
+```
+
+## Example
+
+Raw json files.
+
+```json
+{
+  "title": "stop",
+  "operationId": "stop",
+  "parameters": {
+    "name": "testResource",
+    "stopParameters": {
+      "linkIndex": "link1",
+      "category": "TestCategory"
+    }
+  },
+  "responses": {
+    "200": {}
+  }
+}
+```
+
+## Samples
+
+Generate correct sample with nested body root parameter:
+
+```ts samples
+/** This file path is /samples-dev/stopSample.ts */
+import { TestingClient } from "@azure/internal-test";
+
+/**
+ * This sample demonstrates how to stop with nested body root.
+ *
+ * @summary stop with nested body root.
+ * x-ms-original-file: 2021-10-01-preview/json.json
+ */
+async function stop(): Promise<void> {
+  const endpoint = process.env.TESTING_ENDPOINT || "";
+  const client = new TestingClient(endpoint);
+  const result = await client.stop("testResource", {
+    stopParameters: { linkIndex: "link1", category: "TestCategory" },
+  });
+  console.log(result);
+}
+
+async function main(): Promise<void> {
+  await stop();
+}
+
+main().catch(console.error);
+```


### PR DESCRIPTION
## Problem

When an operation has a `@bodyRoot` property nested inside a wrapper model (e.g., `body: { @bodyRoot stopParameters: StopParameters }`), the generated sample code in `samples-dev/` was missing the required `body` parameter entirely.

## Root Cause

In `emitSamples.ts` and `exampleValueHelpers.ts`, `prepareExampleParameters` uses `bodyParam.name` (`"stopParameters"`) as the example parameter name. However, the function signature parameter is the wrapper `"body"`. When the reorder logic does `paramValueMap.get("body")`, it returns `undefined` because the map key is `"stopParameters"`, causing the body parameter to be dropped.

## Fix

Use `bodyParam.methodParameterSegments` to detect nested body parameters. When nested (single path with >1 segments):
1. Use the first segment's name as the parameter name (the method-level wrapper)
2. Wrap the example value with the intermediate property names to match the wrapper structure

## Testing

- All 639 unit tests pass
- Regenerated networkGateway smoke test confirms sample now correctly includes the body parameter

Fixes #3968
